### PR TITLE
Feature/sources endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/gin-gonic/gin v1.9.1
 	github.com/go-playground/validator/v10 v10.16.0
 	github.com/stretchr/testify v1.8.4
+	google.golang.org/api v0.114.0
 	google.golang.org/grpc v1.56.3
 )
 
@@ -55,7 +56,6 @@ require (
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
-	google.golang.org/api v0.114.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/appengine/v2 v2.0.2 // indirect
 	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1 // indirect

--- a/handlers/source_handler.go
+++ b/handlers/source_handler.go
@@ -62,23 +62,29 @@ func (h *sourceHandler) CreateNewSource(c *gin.Context) {
 
 func (h *sourceHandler) UpdateSource(c *gin.Context) {
 	id := c.Param("id")
-	var newSource models.Source
+	var updatedSource models.SourceUpdate
 
-	if err := c.ShouldBindJSON(&newSource); err != nil {
+	if err := c.ShouldBindJSON(&updatedSource); err != nil {
 		c.AbortWithStatusJSON(error_utils.APIInvalidRequestBody{DetailErr: err}.GetAPIError())
 		return
 	}
 
-	newSource.UID = id
-	err := h.s.UpdateSource(newSource)
+	source := updatedSource.ParseSource()
+
+	source.UID = id
+	source, err := h.s.UpdateSource(source)
 
 	if err != nil {
-		apiErr := error_utils.CheckServiceErrors(newSource.UID, err, "source")
+		apiErr := error_utils.CheckServiceErrors(id, err, "source")
 		c.AbortWithStatusJSON(apiErr.GetAPIError())
 		return
 	}
 
-	c.Status(http.StatusCreated)
+	var sourceData models.SourceRetrieve
+
+	sourceData.ParseSource(source)
+
+	c.JSON(http.StatusCreated, sourceData)
 }
 
 func (h *sourceHandler) DeleteSource(c *gin.Context) {

--- a/handlers/source_handler.go
+++ b/handlers/source_handler.go
@@ -23,7 +23,9 @@ func (h *sourceHandler) GetSourceByID(c *gin.Context) {
 	id := c.Param("id")
 
 	source, err := h.s.GetSourceByID(id)
-	source.UID = id
+	sourceData := models.SourceRetrieve{}
+
+	sourceData.ParseSource(source)
 
 	if err != nil {
 		apiErr := error_utils.CheckServiceErrors(id, err, "source")
@@ -31,7 +33,7 @@ func (h *sourceHandler) GetSourceByID(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, source)
+	c.JSON(http.StatusOK, sourceData)
 }
 
 func (h *sourceHandler) CreateNewSource(c *gin.Context) {

--- a/handlers/source_handler.go
+++ b/handlers/source_handler.go
@@ -63,7 +63,7 @@ func (h *sourceHandler) UpdateSource(c *gin.Context) {
 	}
 
 	newSource.UID = id
-	err := h.s.CreateNewSource(newSource)
+	err := h.s.UpdateSource(newSource)
 
 	if err != nil {
 		apiErr := error_utils.CheckServiceErrors(newSource.UID, err, "source")

--- a/handlers/source_handler.go
+++ b/handlers/source_handler.go
@@ -83,6 +83,12 @@ func (h *sourceHandler) UpdateSource(c *gin.Context) {
 	source := updatedSource.ParseSource()
 
 	source.UID = id
+	userID, exists := c.Get("user")
+	if !exists {
+		c.AbortWithStatusJSON(error_utils.CantGetUser{}.GetAPIError())
+		return
+	}
+	source.OwnerId = userID.(string)
 	source, err := h.s.UpdateSource(source)
 
 	if err != nil {

--- a/handlers/source_handler.go
+++ b/handlers/source_handler.go
@@ -35,17 +35,19 @@ func (h *sourceHandler) GetSourceByID(c *gin.Context) {
 }
 
 func (h *sourceHandler) CreateNewSource(c *gin.Context) {
-	var newSource models.Source
+	var newSource models.SourceCreate
 
 	if err := c.ShouldBindJSON(&newSource); err != nil {
 		c.AbortWithStatusJSON(error_utils.APIInvalidRequestBody{DetailErr: err}.GetAPIError())
 		return
 	}
 
-	err := h.s.CreateNewSource(newSource)
+	source := newSource.ParseSource()
+
+	err := h.s.CreateNewSource(source)
 
 	if err != nil {
-		apiErr := error_utils.CheckServiceErrors(newSource.UID, err, "source")
+		apiErr := error_utils.CheckServiceErrors(source.UID, err, "source")
 		c.AbortWithStatusJSON(apiErr.GetAPIError())
 		return
 	}

--- a/handlers/source_handler.go
+++ b/handlers/source_handler.go
@@ -46,7 +46,7 @@ func (h *sourceHandler) CreateNewSource(c *gin.Context) {
 
 	source := newSource.ParseSource()
 
-	err := h.s.CreateNewSource(source)
+	source, err := h.s.CreateNewSource(source)
 
 	if err != nil {
 		apiErr := error_utils.CheckServiceErrors(source.UID, err, "source")
@@ -54,7 +54,10 @@ func (h *sourceHandler) CreateNewSource(c *gin.Context) {
 		return
 	}
 
-	c.Status(http.StatusCreated)
+	sourceData := models.SourceRetrieve{}
+	sourceData.ParseSource(source)
+
+	c.JSON(http.StatusCreated, sourceData)
 }
 
 func (h *sourceHandler) UpdateSource(c *gin.Context) {

--- a/handlers/source_handler.go
+++ b/handlers/source_handler.go
@@ -106,8 +106,13 @@ func (h *sourceHandler) UpdateSource(c *gin.Context) {
 
 func (h *sourceHandler) DeleteSource(c *gin.Context) {
 	id := c.Param("id")
+	userID, exists := c.Get("user")
+	if !exists {
+		c.AbortWithStatusJSON(error_utils.CantGetUser{}.GetAPIError())
+		return
+	}
 
-	err := h.s.DeleteSource(id)
+	err := h.s.DeleteSource(id, userID.(string))
 
 	if err != nil {
 		apiErr := error_utils.CheckServiceErrors(id, err, "source")

--- a/handlers/source_handler.go
+++ b/handlers/source_handler.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/AndresCRamos/midas-app-api/models"
 	"github.com/AndresCRamos/midas-app-api/services"
+	util_models "github.com/AndresCRamos/midas-app-api/utils/api/models"
 	error_utils "github.com/AndresCRamos/midas-app-api/utils/errors"
 	"github.com/gin-gonic/gin"
 )
@@ -62,7 +63,7 @@ func (h *sourceHandler) GetSourcesByUser(c *gin.Context) {
 		return
 	}
 
-	sourceSearch, err := h.s.GetSourcesByUser(userID.(string), page)
+	sourceSearchResult, err := h.s.GetSourcesByUser(userID.(string), page)
 
 	if err != nil {
 		apiErr := error_utils.CheckServiceErrors(userID.(string), err, "source")
@@ -70,7 +71,22 @@ func (h *sourceHandler) GetSourcesByUser(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, sourceSearch)
+	sourceRetrievedData := []models.SourceRetrieve{}
+
+	for _, sourceData := range sourceSearchResult.Data {
+		retrievedData := models.SourceRetrieve{}
+		retrievedData.ParseSource(sourceData)
+		sourceRetrievedData = append(sourceRetrievedData, retrievedData)
+	}
+
+	sourceSearchRetrieve := util_models.PaginatedSearch[models.SourceRetrieve]{
+		CurrentPage: sourceSearchResult.CurrentPage,
+		TotalData:   sourceSearchResult.TotalData,
+		PageSize:    sourceSearchResult.TotalData,
+		Data:        sourceRetrievedData,
+	}
+
+	c.JSON(http.StatusOK, sourceSearchRetrieve)
 }
 
 func (h *sourceHandler) CreateNewSource(c *gin.Context) {

--- a/handlers/source_handler.go
+++ b/handlers/source_handler.go
@@ -57,9 +57,7 @@ func (h *sourceHandler) GetSourcesByUser(c *gin.Context) {
 	if !exists {
 		page = 1
 	} else if page, err = strconv.Atoi(pageStr); err != nil {
-		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{
-			"error": "page must be a number",
-		})
+		c.AbortWithStatusJSON(util_models.PaginatedTypeError{}.GetAPIError())
 		return
 	}
 

--- a/handlers/source_handler.go
+++ b/handlers/source_handler.go
@@ -45,6 +45,11 @@ func (h *sourceHandler) CreateNewSource(c *gin.Context) {
 	}
 
 	source := newSource.ParseSource()
+	userID, exists := c.Get("user")
+	if !exists {
+		c.AbortWithStatusJSON(error_utils.CantGetUser{}.GetAPIError())
+	}
+	source.OwnerId = userID.(string)
 
 	source, err := h.s.CreateNewSource(source)
 

--- a/handlers/source_handler.go
+++ b/handlers/source_handler.go
@@ -21,8 +21,13 @@ func NewSourceHandler(s services.SourceService) *sourceHandler {
 
 func (h *sourceHandler) GetSourceByID(c *gin.Context) {
 	id := c.Param("id")
+	userID, exists := c.Get("user")
+	if !exists {
+		c.AbortWithStatusJSON(error_utils.CantGetUser{}.GetAPIError())
+		return
+	}
 
-	source, err := h.s.GetSourceByID(id)
+	source, err := h.s.GetSourceByID(id, userID.(string))
 	sourceData := models.SourceRetrieve{}
 
 	sourceData.ParseSource(source)
@@ -48,6 +53,7 @@ func (h *sourceHandler) CreateNewSource(c *gin.Context) {
 	userID, exists := c.Get("user")
 	if !exists {
 		c.AbortWithStatusJSON(error_utils.CantGetUser{}.GetAPIError())
+		return
 	}
 	source.OwnerId = userID.(string)
 

--- a/handlers/source_handler.go
+++ b/handlers/source_handler.go
@@ -1,0 +1,89 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/AndresCRamos/midas-app-api/models"
+	"github.com/AndresCRamos/midas-app-api/services"
+	error_utils "github.com/AndresCRamos/midas-app-api/utils/errors"
+	"github.com/gin-gonic/gin"
+)
+
+type sourceHandler struct {
+	s services.SourceService
+}
+
+func NewSourceHandler(s services.SourceService) *sourceHandler {
+	return &sourceHandler{
+		s: s,
+	}
+}
+
+func (h *sourceHandler) GetSourceByID(c *gin.Context) {
+	id := c.Param("id")
+
+	source, err := h.s.GetSourceByID(id)
+	source.UID = id
+
+	if err != nil {
+		apiErr := error_utils.CheckServiceErrors(id, err, "source")
+		c.AbortWithStatusJSON(apiErr.GetAPIError())
+		return
+	}
+
+	c.JSON(http.StatusOK, source)
+}
+
+func (h *sourceHandler) CreateNewSource(c *gin.Context) {
+	var newSource models.Source
+
+	if err := c.ShouldBindJSON(&newSource); err != nil {
+		c.AbortWithStatusJSON(error_utils.APIInvalidRequestBody{DetailErr: err}.GetAPIError())
+		return
+	}
+
+	err := h.s.CreateNewSource(newSource)
+
+	if err != nil {
+		apiErr := error_utils.CheckServiceErrors(newSource.UID, err, "source")
+		c.AbortWithStatusJSON(apiErr.GetAPIError())
+		return
+	}
+
+	c.Status(http.StatusCreated)
+}
+
+func (h *sourceHandler) UpdateSource(c *gin.Context) {
+	id := c.Param("id")
+	var newSource models.Source
+
+	if err := c.ShouldBindJSON(&newSource); err != nil {
+		c.AbortWithStatusJSON(error_utils.APIInvalidRequestBody{DetailErr: err}.GetAPIError())
+		return
+	}
+
+	newSource.UID = id
+	err := h.s.CreateNewSource(newSource)
+
+	if err != nil {
+		apiErr := error_utils.CheckServiceErrors(newSource.UID, err, "source")
+		c.AbortWithStatusJSON(apiErr.GetAPIError())
+		return
+	}
+
+	c.Status(http.StatusCreated)
+}
+
+func (h *sourceHandler) DeleteSource(c *gin.Context) {
+	id := c.Param("id")
+
+	err := h.s.DeleteSource(id)
+
+	if err != nil {
+		apiErr := error_utils.CheckServiceErrors(id, err, "source")
+		c.AbortWithStatusJSON(apiErr.GetAPIError())
+		return
+	}
+
+	c.Status(http.StatusOK)
+}

--- a/handlers/source_handler_test.go
+++ b/handlers/source_handler_test.go
@@ -1,0 +1,415 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/AndresCRamos/midas-app-api/models"
+	"github.com/AndresCRamos/midas-app-api/services"
+	error_utils "github.com/AndresCRamos/midas-app-api/utils/errors"
+	test_utils "github.com/AndresCRamos/midas-app-api/utils/test"
+	"github.com/AndresCRamos/midas-app-api/utils/test/mocks"
+	"github.com/AndresCRamos/midas-app-api/utils/validations"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	sourceValidationTests = []string{"No UID"}
+	mapNameID             = map[string]string{
+		"Success":         "0",
+		"Fail to connect": "1",
+		"Not Found":       "2",
+	}
+)
+
+func Test_sourceHandler_CreateNewSource(t *testing.T) {
+	mockService := mocks.SourceServiceMock{}
+
+	fields := test_utils.Fields{
+		"mockService": mockService,
+	}
+
+	tests := []test_utils.TestCase{
+		{
+			Name:   "Success",
+			Fields: fields,
+			Args: test_utils.Args{
+				"source":       &models.Source{Name: "Success", UID: "0", OwnerId: "0"},
+				"expectedCode": http.StatusCreated,
+			},
+			WantErr:     false,
+			ExpectedErr: nil,
+			PreTest:     nil,
+		},
+		{
+			Name:   "Fail to connect",
+			Fields: fields,
+			Args: test_utils.Args{
+				"source":       &models.Source{Name: "CantConnect", UID: "0", OwnerId: "0"},
+				"expectedCode": http.StatusInternalServerError,
+			},
+			WantErr:     true,
+			ExpectedErr: error_utils.APIUnknown{},
+			PreTest:     nil,
+		},
+		{
+			Name:   "Duplicated Source",
+			Fields: fields,
+			Args: test_utils.Args{
+				"source":       &models.Source{Name: "Duplicated", UID: "0", OwnerId: "0"},
+				"expectedCode": http.StatusBadRequest,
+			},
+			WantErr:     true,
+			ExpectedErr: error_utils.SourceDuplicated{SourceID: "0"},
+			PreTest:     nil,
+		},
+		{
+			Name:   "No UID",
+			Fields: fields,
+			Args: test_utils.Args{
+				"source":            &models.Source{Name: "Bad request", OwnerId: "0"},
+				"expectedCode":      http.StatusBadRequest,
+				"expectedErrDetail": []string{"field uid is required"},
+			},
+			WantErr:     true,
+			ExpectedErr: error_utils.APIInvalidRequestBody{},
+			PreTest:     nil,
+		},
+	}
+
+	for _, tt := range tests {
+		gin.SetMode(gin.ReleaseMode)
+		testRouter := gin.Default()
+		err := validations.AddCustomValidations()
+		if err != nil {
+			t.Fatal(err)
+		}
+		w := httptest.NewRecorder()
+		t.Run(tt.Name, func(t *testing.T) {
+			if tt.PreTest != nil {
+				tt.PreTest(t)
+			}
+			mockService := test_utils.GetFieldByNameAndType(t, tt.Fields, "mockService", new(services.SourceService))
+			h := &sourceHandler{
+				s: mockService.(services.SourceService),
+			}
+
+			body := getSourceTestBody(t, tt)
+
+			testRouter.POST("/", h.CreateNewSource)
+			req, _ := http.NewRequest("POST", "/", bytes.NewBuffer(body))
+			testRouter.ServeHTTP(w, req)
+			expectedCode := test_utils.GetArgByNameAndType(t, tt.Args, "expectedCode", 0)
+			assert.Equal(t, expectedCode, w.Code)
+			if !tt.WantErr {
+			} else {
+				var errMessage map[string]interface{}
+				err := json.Unmarshal(w.Body.Bytes(), &errMessage)
+				assert.NoError(t, err)
+				assert.Equal(t, tt.ExpectedErr.Error(), errMessage["error"])
+
+				if slices.Contains(sourceValidationTests, tt.Name) {
+					expectedDetail := test_utils.GetArgByNameAndType(t, tt.Args, "expectedErrDetail", []string{}).([]string)
+					val, ok := errMessage["detail"]
+					if ok {
+						assert.Equal(t, expectedDetail[0], val.(string))
+						return
+					}
+					val, ok = errMessage["details"]
+					if ok {
+						assert.ElementsMatch(t, expectedDetail, val)
+						return
+					}
+
+					errMsjByte, _ := json.MarshalIndent(errMessage, "", " ")
+
+					t.Fatalf("Cant get error details from error message:\n %s", string(errMsjByte))
+				}
+
+			}
+		})
+	}
+}
+
+func Test_sourceHandler_GetSourceByID(t *testing.T) {
+	mockService := mocks.SourceServiceMock{}
+
+	fields := test_utils.Fields{
+		"mockService": mockService,
+	}
+
+	tests := []test_utils.TestCase{
+		{
+			Name:   "Success",
+			Fields: fields,
+			Args: test_utils.Args{
+				"sourceID":       "0",
+				"expectedCode":   http.StatusOK,
+				"expectedSource": mocks.TestSource,
+			},
+			WantErr:     false,
+			ExpectedErr: nil,
+			PreTest:     nil,
+		},
+		{
+			Name:   "Fail to connect",
+			Fields: fields,
+			Args: test_utils.Args{
+				"sourceID":     "1",
+				"expectedCode": http.StatusInternalServerError,
+			},
+			WantErr:     true,
+			ExpectedErr: error_utils.APIUnknown{},
+			PreTest:     nil,
+		},
+		{
+			Name:   "Not Found",
+			Fields: fields,
+			Args: test_utils.Args{
+				"sourceID":     "2",
+				"expectedCode": http.StatusNotFound,
+			},
+			WantErr:     true,
+			ExpectedErr: error_utils.SourceNotFound{SourceID: "2"},
+			PreTest:     nil,
+		},
+	}
+
+	for _, tt := range tests {
+		gin.SetMode(gin.ReleaseMode)
+		testRouter := gin.Default()
+		w := httptest.NewRecorder()
+		t.Run(tt.Name, func(t *testing.T) {
+			var body []byte
+			if tt.PreTest != nil {
+				tt.PreTest(t)
+			}
+			mockService := test_utils.GetFieldByNameAndType(t, tt.Fields, "mockService", new(services.SourceService))
+			h := &sourceHandler{
+				s: mockService.(services.SourceService),
+			}
+
+			sourceID := test_utils.GetArgByNameAndType(t, tt.Args, "sourceID", "").(string)
+			url := fmt.Sprintf("/%s", sourceID)
+
+			testRouter.GET("/:id", h.GetSourceByID)
+			req, _ := http.NewRequest("GET", url, bytes.NewBuffer(body))
+			testRouter.ServeHTTP(w, req)
+			expectedCode := test_utils.GetArgByNameAndType(t, tt.Args, "expectedCode", 0)
+			assert.Equal(t, expectedCode, w.Code)
+			if !tt.WantErr {
+				var resSource models.Source
+				testSource := test_utils.GetArgByNameAndType(t, tt.Args, "expectedSource", models.Source{})
+				err := json.Unmarshal(w.Body.Bytes(), &resSource)
+				assert.NoError(t, err)
+				assert.Equal(t, testSource, resSource)
+			} else {
+				var errMessage map[string]interface{}
+				err := json.Unmarshal(w.Body.Bytes(), &errMessage)
+				assert.NoError(t, err)
+				assert.Equal(t, tt.ExpectedErr.Error(), errMessage["error"])
+			}
+		})
+	}
+}
+func Test_sourceHandler_UpdateSource(t *testing.T) {
+	mockServiceMain := mocks.SourceServiceMock{}
+
+	fields := test_utils.Fields{
+		"mockService": mockServiceMain,
+	}
+
+	tests := []test_utils.TestCase{
+		{
+			Name:   "Success",
+			Fields: fields,
+			Args: test_utils.Args{
+				"source":       &models.Source{Name: "Success", UID: "0", OwnerId: "0"},
+				"expectedCode": http.StatusCreated,
+			},
+			WantErr:     false,
+			ExpectedErr: nil,
+			PreTest:     nil,
+		},
+		{
+			Name:   "Fail to connect",
+			Fields: fields,
+			Args: test_utils.Args{
+				"source":       &models.Source{Name: "CantConnect", UID: "1", OwnerId: "0"},
+				"expectedCode": http.StatusInternalServerError,
+			},
+			WantErr:     true,
+			ExpectedErr: error_utils.APIUnknown{},
+			PreTest:     nil,
+		},
+		{
+			Name:   "Not Found",
+			Fields: fields,
+			Args: test_utils.Args{
+				"source":       &models.Source{Name: "Duplicated", UID: "2", OwnerId: "0"},
+				"expectedCode": http.StatusNotFound,
+			},
+			WantErr:     true,
+			ExpectedErr: error_utils.SourceNotFound{SourceID: "2"},
+			PreTest:     nil,
+		},
+	}
+
+	for _, tt := range tests {
+		gin.SetMode(gin.ReleaseMode)
+		testRouter := gin.Default()
+		err := validations.AddCustomValidations()
+		if err != nil {
+			t.Fatal(err)
+		}
+		w := httptest.NewRecorder()
+		t.Run(tt.Name, func(t *testing.T) {
+			if tt.PreTest != nil {
+				tt.PreTest(t)
+			}
+			mockService := test_utils.GetFieldByNameAndType(t, tt.Fields, "mockService", new(services.SourceService))
+			h := &sourceHandler{
+				s: mockService.(services.SourceService),
+			}
+
+			body := getSourceTestBody(t, tt)
+
+			testRouter.PUT("/:id", h.UpdateSource)
+			id := mapNameID[tt.Name]
+			req, err := http.NewRequest("PUT", "/"+id, bytes.NewBuffer(body))
+			assert.NoError(t, err)
+			testRouter.ServeHTTP(w, req)
+			expectedCode := test_utils.GetArgByNameAndType(t, tt.Args, "expectedCode", 0)
+			assert.Equal(t, expectedCode, w.Code)
+			if !tt.WantErr {
+				assert.Empty(t, w.Body.String())
+			} else {
+				var errMessage map[string]interface{}
+				err := json.Unmarshal(w.Body.Bytes(), &errMessage)
+				assert.NoError(t, err)
+				assert.Equal(t, tt.ExpectedErr.Error(), errMessage["error"])
+
+				if slices.Contains(sourceValidationTests, tt.Name) {
+					expectedDetail := test_utils.GetArgByNameAndType(t, tt.Args, "expectedErrDetail", []string{}).([]string)
+					val, ok := errMessage["detail"]
+					if ok {
+						assert.Equal(t, expectedDetail[0], val.(string))
+						return
+					}
+					val, ok = errMessage["details"]
+					if ok {
+						assert.ElementsMatch(t, expectedDetail, val)
+						return
+					}
+
+					errMsjByte, _ := json.MarshalIndent(errMessage, "", " ")
+
+					t.Fatalf("Cant get error details from error message:\n %s", string(errMsjByte))
+				}
+
+			}
+		})
+	}
+}
+
+func Test_sourceHandler_DeleteSource(t *testing.T) {
+	mockService := mocks.SourceServiceMock{}
+
+	fields := test_utils.Fields{
+		"mockService": mockService,
+	}
+
+	tests := []test_utils.TestCase{
+		{
+			Name:   "Success",
+			Fields: fields,
+			Args: test_utils.Args{
+				"sourceID":       "0",
+				"expectedCode":   http.StatusOK,
+				"expectedSource": mocks.TestSource,
+			},
+			WantErr:     false,
+			ExpectedErr: nil,
+			PreTest:     nil,
+		},
+		{
+			Name:   "Fail to connect",
+			Fields: fields,
+			Args: test_utils.Args{
+				"sourceID":     "1",
+				"expectedCode": http.StatusInternalServerError,
+			},
+			WantErr:     true,
+			ExpectedErr: error_utils.APIUnknown{},
+			PreTest:     nil,
+		},
+		{
+			Name:   "Not Found",
+			Fields: fields,
+			Args: test_utils.Args{
+				"sourceID":     "2",
+				"expectedCode": http.StatusNotFound,
+			},
+			WantErr:     true,
+			ExpectedErr: error_utils.SourceNotFound{SourceID: "2"},
+			PreTest:     nil,
+		},
+	}
+
+	for _, tt := range tests {
+		gin.SetMode(gin.ReleaseMode)
+		testRouter := gin.Default()
+		w := httptest.NewRecorder()
+		t.Run(tt.Name, func(t *testing.T) {
+			var body []byte
+			if tt.PreTest != nil {
+				tt.PreTest(t)
+			}
+			mockService := test_utils.GetFieldByNameAndType(t, tt.Fields, "mockService", new(services.SourceService))
+			h := &sourceHandler{
+				s: mockService.(services.SourceService),
+			}
+
+			sourceID := test_utils.GetArgByNameAndType(t, tt.Args, "sourceID", "").(string)
+			url := fmt.Sprintf("/%s", sourceID)
+
+			testRouter.DELETE("/:id", h.DeleteSource)
+			req, _ := http.NewRequest("DELETE", url, bytes.NewBuffer(body))
+			testRouter.ServeHTTP(w, req)
+			expectedCode := test_utils.GetArgByNameAndType(t, tt.Args, "expectedCode", 0)
+			assert.Equal(t, expectedCode, w.Code)
+			if !tt.WantErr {
+				assert.Empty(t, w.Body.String())
+
+			} else {
+				var errMessage map[string]interface{}
+				err := json.Unmarshal(w.Body.Bytes(), &errMessage)
+				assert.NoError(t, err)
+				assert.Equal(t, tt.ExpectedErr.Error(), errMessage["error"])
+			}
+		})
+	}
+}
+
+func getSourceTestBody(test *testing.T, testCase test_utils.TestCase) []byte {
+	testName := strings.Split(test.Name(), "/")[1]
+
+	switch testName {
+	case "Bad_request":
+		body, _ := json.Marshal(map[string]any{
+			"InvalidUser": "Username",
+		})
+		return body
+	default:
+		bodyStruct := test_utils.GetArgByNameAndType(test, testCase.Args, "source", new(models.Source)).(*models.Source)
+		body, _ := json.Marshal(bodyStruct)
+		return body
+	}
+}

--- a/handlers/source_handler_test.go
+++ b/handlers/source_handler_test.go
@@ -27,9 +27,10 @@ var (
 		"No Owner ID",
 	}
 	mapNameID = map[string]string{
-		"Success":         "0",
-		"Fail to connect": "1",
-		"Not Found":       "2",
+		"Success":           "0",
+		"Fail to connect":   "1",
+		"Not Found":         "2",
+		"Cant change owner": "4",
 	}
 )
 
@@ -270,7 +271,7 @@ func Test_sourceHandler_UpdateSource(t *testing.T) {
 			Name:   "Not Found",
 			Fields: fields,
 			Args: test_utils.Args{
-				"source":       &models.Source{Name: "Duplicated", UID: "2", OwnerId: "0"},
+				"source":       &models.SourceUpdate{Name: "Duplicated", OwnerId: "0"},
 				"expectedCode": http.StatusNotFound,
 			},
 			WantErr:     true,
@@ -296,7 +297,7 @@ func Test_sourceHandler_UpdateSource(t *testing.T) {
 				s: mockService.(services.SourceService),
 			}
 
-			body := getSourceTestBody[models.Source](t, tt)
+			body := getSourceTestBody[models.SourceUpdate](t, tt)
 
 			testRouter.PUT("/:id", h.UpdateSource)
 			id := mapNameID[tt.Name]

--- a/handlers/source_handler_test.go
+++ b/handlers/source_handler_test.go
@@ -288,8 +288,12 @@ func Test_sourceHandler_UpdateSource(t *testing.T) {
 			testRouter.ServeHTTP(w, req)
 			expectedCode := test_utils.GetArgByNameAndType(t, tt.Args, "expectedCode", 0)
 			assert.Equal(t, expectedCode, w.Code)
+			assert.NotEmpty(t, w.Body.String())
 			if !tt.WantErr {
-				assert.Empty(t, w.Body.String())
+				var created models.SourceRetrieve
+				err := json.Unmarshal(w.Body.Bytes(), &created)
+				assert.NoError(t, err)
+
 			} else {
 				var errMessage map[string]interface{}
 				err := json.Unmarshal(w.Body.Bytes(), &errMessage)

--- a/handlers/source_handler_test.go
+++ b/handlers/source_handler_test.go
@@ -24,8 +24,7 @@ import (
 
 var (
 	sourceValidationTests = []string{
-		"No UID",
-		"No Owner ID",
+		"No Name",
 	}
 	mapNameID = map[string]string{
 		"Success":         "0",
@@ -564,7 +563,7 @@ func getSourceTestBody[T any](test *testing.T, testCase test_utils.TestCase) []b
 	switch testName {
 	case "Bad_request":
 		body, _ := json.Marshal(map[string]any{
-			"InvalidUser": "Username",
+			"InvalidBody": "Invalid",
 		})
 		return body
 	default:

--- a/handlers/source_handler_test.go
+++ b/handlers/source_handler_test.go
@@ -249,7 +249,7 @@ func Test_sourceHandler_UpdateSource(t *testing.T) {
 			Name:   "Success",
 			Fields: fields,
 			Args: test_utils.Args{
-				"source":       &models.Source{Name: "Success", UID: "0", OwnerId: "0"},
+				"source":       &models.SourceUpdate{Name: "Success", OwnerId: "0"},
 				"expectedCode": http.StatusCreated,
 			},
 			WantErr:     false,
@@ -260,7 +260,7 @@ func Test_sourceHandler_UpdateSource(t *testing.T) {
 			Name:   "Fail to connect",
 			Fields: fields,
 			Args: test_utils.Args{
-				"source":       &models.Source{Name: "CantConnect", UID: "1", OwnerId: "0"},
+				"source":       &models.SourceUpdate{Name: "CantConnect", OwnerId: "0"},
 				"expectedCode": http.StatusInternalServerError,
 			},
 			WantErr:     true,
@@ -271,11 +271,22 @@ func Test_sourceHandler_UpdateSource(t *testing.T) {
 			Name:   "Not Found",
 			Fields: fields,
 			Args: test_utils.Args{
-				"source":       &models.SourceUpdate{Name: "Duplicated", OwnerId: "0"},
+				"source":       &models.SourceUpdate{Name: "NotFound", OwnerId: "0"},
 				"expectedCode": http.StatusNotFound,
 			},
 			WantErr:     true,
 			ExpectedErr: error_utils.SourceNotFound{SourceID: "2"},
+			PreTest:     nil,
+		},
+		{
+			Name:   "Cant change owner",
+			Fields: fields,
+			Args: test_utils.Args{
+				"source":       &models.SourceUpdate{Name: "CantChangeOwner", OwnerId: "0"},
+				"expectedCode": http.StatusNotFound,
+			},
+			WantErr:     true,
+			ExpectedErr: error_utils.SourceCantChangeOwner{SourceID: "4", OwnerID: "0"},
 			PreTest:     nil,
 		},
 	}

--- a/handlers/source_handler_test.go
+++ b/handlers/source_handler_test.go
@@ -397,6 +397,17 @@ func Test_sourceHandler_DeleteSource(t *testing.T) {
 			ExpectedErr: error_utils.SourceNotFound{SourceID: "2"},
 			PreTest:     nil,
 		},
+		{
+			Name:   "Different user",
+			Fields: fields,
+			Args: test_utils.Args{
+				"sourceID":     "4",
+				"expectedCode": http.StatusNotFound,
+			},
+			WantErr:     true,
+			ExpectedErr: error_utils.SourceDifferentOwner{SourceID: "4", OwnerID: "123"},
+			PreTest:     nil,
+		},
 	}
 
 	for _, tt := range tests {
@@ -416,6 +427,7 @@ func Test_sourceHandler_DeleteSource(t *testing.T) {
 			sourceID := test_utils.GetArgByNameAndType(t, tt.Args, "sourceID", "").(string)
 			url := fmt.Sprintf("/%s", sourceID)
 
+			testRouter.Use(testMiddleware())
 			testRouter.DELETE("/:id", h.DeleteSource)
 			req, _ := http.NewRequest("DELETE", url, bytes.NewBuffer(body))
 			testRouter.ServeHTTP(w, req)

--- a/handlers/source_handler_test.go
+++ b/handlers/source_handler_test.go
@@ -184,6 +184,18 @@ func Test_sourceHandler_GetSourcesByUser(t *testing.T) {
 			ExpectedErr: error_utils.APIUnknown{},
 			PreTest:     nil,
 		},
+		{
+			Name:   "Not enough data",
+			Fields: fields,
+			Args: test_utils.Args{
+				"sourceID":     "1",
+				"expectedCode": http.StatusNotFound,
+				"userID":       "2",
+			},
+			WantErr:     true,
+			ExpectedErr: error_utils.SourceNotEnoughData{},
+			PreTest:     nil,
+		},
 	}
 
 	for _, tt := range tests {

--- a/handlers/source_handler_test.go
+++ b/handlers/source_handler_test.go
@@ -41,7 +41,7 @@ func Test_sourceHandler_CreateNewSource(t *testing.T) {
 			Name:   "Success",
 			Fields: fields,
 			Args: test_utils.Args{
-				"source":       &models.Source{Name: "Success", UID: "0", OwnerId: "0"},
+				"source":       &models.SourceCreate{Name: "Success", OwnerId: "0"},
 				"expectedCode": http.StatusCreated,
 			},
 			WantErr:     false,
@@ -52,7 +52,7 @@ func Test_sourceHandler_CreateNewSource(t *testing.T) {
 			Name:   "Fail to connect",
 			Fields: fields,
 			Args: test_utils.Args{
-				"source":       &models.Source{Name: "CantConnect", UID: "0", OwnerId: "0"},
+				"source":       &models.SourceCreate{Name: "CantConnect", OwnerId: "0"},
 				"expectedCode": http.StatusInternalServerError,
 			},
 			WantErr:     true,
@@ -63,7 +63,7 @@ func Test_sourceHandler_CreateNewSource(t *testing.T) {
 			Name:   "Duplicated Source",
 			Fields: fields,
 			Args: test_utils.Args{
-				"source":       &models.Source{Name: "Duplicated", UID: "0", OwnerId: "0"},
+				"source":       &models.SourceCreate{Name: "Duplicated", OwnerId: "0"},
 				"expectedCode": http.StatusBadRequest,
 			},
 			WantErr:     true,
@@ -74,7 +74,7 @@ func Test_sourceHandler_CreateNewSource(t *testing.T) {
 			Name:   "No UID",
 			Fields: fields,
 			Args: test_utils.Args{
-				"source":            &models.Source{Name: "Bad request", OwnerId: "0"},
+				"source":            &models.SourceCreate{Name: "Bad request", OwnerId: "0"},
 				"expectedCode":      http.StatusBadRequest,
 				"expectedErrDetail": []string{"field uid is required"},
 			},
@@ -101,7 +101,7 @@ func Test_sourceHandler_CreateNewSource(t *testing.T) {
 				s: mockService.(services.SourceService),
 			}
 
-			body := getSourceTestBody(t, tt)
+			body := getSourceTestBody[models.SourceCreate](t, tt)
 
 			testRouter.POST("/", h.CreateNewSource)
 			req, _ := http.NewRequest("POST", "/", bytes.NewBuffer(body))
@@ -279,7 +279,7 @@ func Test_sourceHandler_UpdateSource(t *testing.T) {
 				s: mockService.(services.SourceService),
 			}
 
-			body := getSourceTestBody(t, tt)
+			body := getSourceTestBody[models.Source](t, tt)
 
 			testRouter.PUT("/:id", h.UpdateSource)
 			id := mapNameID[tt.Name]
@@ -398,7 +398,7 @@ func Test_sourceHandler_DeleteSource(t *testing.T) {
 	}
 }
 
-func getSourceTestBody(test *testing.T, testCase test_utils.TestCase) []byte {
+func getSourceTestBody[T any](test *testing.T, testCase test_utils.TestCase) []byte {
 	testName := strings.Split(test.Name(), "/")[1]
 
 	switch testName {
@@ -408,7 +408,7 @@ func getSourceTestBody(test *testing.T, testCase test_utils.TestCase) []byte {
 		})
 		return body
 	default:
-		bodyStruct := test_utils.GetArgByNameAndType(test, testCase.Args, "source", new(models.Source)).(*models.Source)
+		bodyStruct := test_utils.GetArgByNameAndType(test, testCase.Args, "source", new(T)).(*T)
 		body, _ := json.Marshal(bodyStruct)
 		return body
 	}

--- a/handlers/user_handler.go
+++ b/handlers/user_handler.go
@@ -1,8 +1,6 @@
 package handlers
 
 import (
-	"errors"
-	"log"
 	"net/http"
 
 	"github.com/AndresCRamos/midas-app-api/models"
@@ -28,7 +26,7 @@ func (h *userHandler) GetUserByID(c *gin.Context) {
 	user.UID = id
 
 	if err != nil {
-		apiErr := checkServiceErrors(user, err)
+		apiErr := error_utils.CheckServiceErrors(id, err, "user")
 		c.AbortWithStatusJSON(apiErr.GetAPIError())
 		return
 	}
@@ -47,29 +45,10 @@ func (h *userHandler) CreateNewUser(c *gin.Context) {
 	err := h.s.CreateNewUser(newUser)
 
 	if err != nil {
-		apiErr := checkServiceErrors(newUser, err)
+		apiErr := error_utils.CheckServiceErrors(newUser.UID, err, "user")
 		c.AbortWithStatusJSON(apiErr.GetAPIError())
 		return
 	}
 
 	c.Status(http.StatusCreated)
-}
-
-func checkServiceErrors(user models.User, err error) error_utils.APIError {
-	log.Print(err)
-
-	alreadyExists := &error_utils.FirestoreAlreadyExistsError{}
-	unauthorized := &error_utils.FirebaseUnauthorizedError{}
-	notFound := &error_utils.FirestoreNotFoundError{}
-
-	if errors.As(err, unauthorized) {
-		return error_utils.APIUnauthorized{}
-	}
-	if errors.As(err, alreadyExists) {
-		return error_utils.UserDuplicated{UserID: user.UID}
-	}
-	if errors.As(err, notFound) {
-		return error_utils.UserNotFound{UserID: user.UID}
-	}
-	return error_utils.APIUnknown{}
 }

--- a/handlers/user_handler_test.go
+++ b/handlers/user_handler_test.go
@@ -120,7 +120,7 @@ func Test_userHandler_CreateNewUser(t *testing.T) {
 				s: mockService.(services.UserService),
 			}
 
-			body := getTestBody(t, tt)
+			body := getUserTestBody(t, tt)
 
 			testRouter.POST("/", h.CreateNewUser)
 			req, _ := http.NewRequest("POST", "/", bytes.NewBuffer(body))
@@ -239,7 +239,7 @@ func Test_userHandler_GetUserByID(t *testing.T) {
 	}
 }
 
-func getTestBody(test *testing.T, testCase test_utils.TestCase) []byte {
+func getUserTestBody(test *testing.T, testCase test_utils.TestCase) []byte {
 	testName := strings.Split(test.Name(), "/")[1]
 
 	switch testName {

--- a/handlers/user_handler_test.go
+++ b/handlers/user_handler_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 var (
-	validationTests = []string{"No UID", "No Name nor alias, No Name nor alias", "Lastname but no name"}
+	userValidationTests = []string{"No UID", "No Name nor alias, No Name nor alias", "Lastname but no name"}
 )
 
 func Test_userHandler_CreateNewUser(t *testing.T) {
@@ -134,7 +134,7 @@ func Test_userHandler_CreateNewUser(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Equal(t, tt.ExpectedErr.Error(), errMessage["error"])
 
-				if slices.Contains(validationTests, tt.Name) {
+				if slices.Contains(userValidationTests, tt.Name) {
 					expectedDetail := test_utils.GetArgByNameAndType(t, tt.Args, "expectedErrDetail", []string{}).([]string)
 					val, ok := errMessage["detail"]
 					if ok {

--- a/middleware/token.go
+++ b/middleware/token.go
@@ -3,9 +3,9 @@ package middleware
 import (
 	"context"
 	"log"
-	"net/http"
 
 	"firebase.google.com/go/v4/auth"
+	error_utils "github.com/AndresCRamos/midas-app-api/utils/errors"
 	"github.com/gin-gonic/gin"
 )
 
@@ -13,7 +13,7 @@ func VerifyToken(auth *auth.Client) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		authHeader := c.GetHeader("Authorization")
 		if authHeader == "" {
-			c.JSON(http.StatusUnauthorized, gin.H{"error": "Authorization header is missing"})
+			c.JSON(error_utils.EmptyToken{}.GetAPIError())
 			c.Abort()
 			return
 		}
@@ -21,8 +21,8 @@ func VerifyToken(auth *auth.Client) gin.HandlerFunc {
 		idToken := authHeader[len("Bearer "):]
 		token, err := auth.VerifyIDToken(context.Background(), idToken)
 		if err != nil {
-			log.Printf("Error verifying ID token: %v", err)
-			c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid ID token"})
+			log.Printf("Error verifying token %s: %v", idToken, err)
+			c.JSON(error_utils.InvalidToken{}.GetAPIError())
 			c.Abort()
 			return
 		}

--- a/middleware/token.go
+++ b/middleware/token.go
@@ -21,7 +21,7 @@ func VerifyToken(auth *auth.Client) gin.HandlerFunc {
 		idToken := authHeader[len("Bearer "):]
 		token, err := auth.VerifyIDToken(context.Background(), idToken)
 		if err != nil {
-			log.Printf("Error verifying token %s: %v", idToken, err)
+			log.Printf("Error verifying token: %v", err)
 			c.JSON(error_utils.InvalidToken{}.GetAPIError())
 			c.Abort()
 			return

--- a/models/sources.go
+++ b/models/sources.go
@@ -21,14 +21,12 @@ func (s *Source) NewUpdatedAtDate() {
 
 type SourceCreate struct {
 	Name        string `json:"name" binding:"required"`
-	OwnerId     string `json:"ownerId" binding:"required"`
 	Description string `json:"description,omitempty"`
 }
 
 func (sc SourceCreate) ParseSource() Source {
 	return Source{
 		Name:        sc.Name,
-		OwnerId:     sc.OwnerId,
 		Description: sc.Description,
 	}
 }

--- a/models/sources.go
+++ b/models/sources.go
@@ -3,12 +3,42 @@ package models
 import "time"
 
 type Source struct {
-	UID         string    `json:"uid" firestore:"uid" binding:"required"`
-	Name        string    `json:"name" firestore:"name" binding:"required"`
-	OwnerId     string    `json:"ownerId" firestore:"owner" binding:"required"`
-	Description string    `json:"description,omitempty" firestore:"description"`
-	CreatedAt   time.Time `json:"-" firestore:"created_at"`
-	UpdatedAt   time.Time `json:"-" firestore:"updated_at"`
+	UID         string    `firestore:"uid"`
+	Name        string    `firestore:"name"`
+	OwnerId     string    `firestore:"owner"`
+	Description string    `firestore:"description"`
+	CreatedAt   time.Time `firestore:"created_at"`
+	UpdatedAt   time.Time `firestore:"updated_at"`
+}
+
+type SourceCreate struct {
+	Name        string `json:"name" binding:"required"`
+	OwnerId     string `json:"ownerId" binding:"required"`
+	Description string `json:"description,omitempty"`
+}
+
+func (sc SourceCreate) ParseSource() Source {
+	return Source{
+		Name:        sc.Name,
+		OwnerId:     sc.OwnerId,
+		Description: sc.Description,
+	}
+}
+
+type SourceRetrieve struct {
+	UID         string    `json:"uid"`
+	Name        string    `json:"name"`
+	Description string    `json:"description,omitempty"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+func (sr *SourceRetrieve) ParseSource(src Source) {
+	sr.UID = src.UID
+	sr.Name = src.Name
+	sr.Description = src.Description
+	sr.CreatedAt = src.CreatedAt
+	sr.UpdatedAt = src.UpdatedAt
 }
 
 func (s *Source) NewCreationAtDate() {

--- a/models/sources.go
+++ b/models/sources.go
@@ -3,10 +3,10 @@ package models
 import "time"
 
 type Source struct {
-	UID         string
-	Name        string
-	OwnerId     string
-	Description string
+	UID         string `json:"uid" binding:"required"`
+	Name        string `json:"name" binding:"required"`
+	OwnerId     string `json:"ownerId" binding:"required"`
+	Description string `json:"description"`
 	createdAt   time.Time
 	updatedAt   time.Time
 }

--- a/models/sources.go
+++ b/models/sources.go
@@ -11,6 +11,14 @@ type Source struct {
 	UpdatedAt   time.Time `firestore:"updated_at"`
 }
 
+func (s *Source) NewCreationAtDate() {
+	s.CreatedAt = time.Now()
+}
+
+func (s *Source) NewUpdatedAtDate() {
+	s.UpdatedAt = time.Now()
+}
+
 type SourceCreate struct {
 	Name        string `json:"name" binding:"required"`
 	OwnerId     string `json:"ownerId" binding:"required"`
@@ -41,10 +49,16 @@ func (sr *SourceRetrieve) ParseSource(src Source) {
 	sr.UpdatedAt = src.UpdatedAt
 }
 
-func (s *Source) NewCreationAtDate() {
-	s.CreatedAt = time.Now()
+type SourceUpdate struct {
+	Name        string `json:"name"`
+	OwnerId     string `json:"ownerId" binding:"required"`
+	Description string `json:"description"`
 }
 
-func (s *Source) NewUpdatedAtDate() {
-	s.UpdatedAt = time.Now()
+func (su SourceUpdate) ParseSource() Source {
+	return Source{
+		Name:        su.Name,
+		OwnerId:     su.OwnerId,
+		Description: su.Description,
+	}
 }

--- a/models/sources.go
+++ b/models/sources.go
@@ -3,18 +3,18 @@ package models
 import "time"
 
 type Source struct {
-	UID         string `json:"uid" firestore:"uid" binding:"required"`
-	Name        string `json:"name" firestore:"name" binding:"required"`
-	OwnerId     string `json:"ownerId" firestore:"owner" binding:"required"`
-	Description string `json:"description,omitempty" firestore:"description"`
-	createdAt   time.Time
-	updatedAt   time.Time
+	UID         string    `json:"uid" firestore:"uid" binding:"required"`
+	Name        string    `json:"name" firestore:"name" binding:"required"`
+	OwnerId     string    `json:"ownerId" firestore:"owner" binding:"required"`
+	Description string    `json:"description,omitempty" firestore:"description"`
+	CreatedAt   time.Time `json:"-" firestore:"created_at"`
+	UpdatedAt   time.Time `json:"-" firestore:"updated_at"`
 }
 
 func (s *Source) NewCreationAtDate() {
-	s.createdAt = time.Now()
+	s.CreatedAt = time.Now()
 }
 
 func (s *Source) NewUpdatedAtDate() {
-	s.updatedAt = time.Now()
+	s.UpdatedAt = time.Now()
 }

--- a/models/sources.go
+++ b/models/sources.go
@@ -49,14 +49,12 @@ func (sr *SourceRetrieve) ParseSource(src Source) {
 
 type SourceUpdate struct {
 	Name        string `json:"name"`
-	OwnerId     string `json:"ownerId" binding:"required"`
 	Description string `json:"description"`
 }
 
 func (su SourceUpdate) ParseSource() Source {
 	return Source{
 		Name:        su.Name,
-		OwnerId:     su.OwnerId,
 		Description: su.Description,
 	}
 }

--- a/models/sources.go
+++ b/models/sources.go
@@ -3,10 +3,10 @@ package models
 import "time"
 
 type Source struct {
-	UID         string `json:"uid" binding:"required"`
-	Name        string `json:"name" binding:"required"`
-	OwnerId     string `json:"ownerId" binding:"required"`
-	Description string `json:"description"`
+	UID         string `json:"uid" firestore:"uid" binding:"required"`
+	Name        string `json:"name" firestore:"name" binding:"required"`
+	OwnerId     string `json:"ownerId" firestore:"owner" binding:"required"`
+	Description string `json:"description,omitempty" firestore:"description"`
 	createdAt   time.Time
 	updatedAt   time.Time
 }

--- a/models/sources.go
+++ b/models/sources.go
@@ -7,6 +7,14 @@ type Source struct {
 	Name        string
 	OwnerId     string
 	Description string
-	CreatedAt   time.Time
-	UpdatedAt   time.Time
+	createdAt   time.Time
+	updatedAt   time.Time
+}
+
+func (s *Source) NewCreationAtDate() {
+	s.createdAt = time.Now()
+}
+
+func (s *Source) NewUpdatedAtDate() {
+	s.updatedAt = time.Now()
 }

--- a/repository/source_repo.go
+++ b/repository/source_repo.go
@@ -11,7 +11,7 @@ import (
 type SourceRepository interface {
 	GetSourceByID(id string) (models.Source, error)
 	CreateNewSource(Source models.Source) error
-	UpdateNewSource(id string, Source models.Source) error
+	UpdateNewSource(Source models.Source) error
 	DeleteSource(id string) error
 }
 

--- a/repository/source_repo.go
+++ b/repository/source_repo.go
@@ -1,0 +1,58 @@
+package repository
+
+import (
+	"context"
+
+	"cloud.google.com/go/firestore"
+	"github.com/AndresCRamos/midas-app-api/models"
+	error_utils "github.com/AndresCRamos/midas-app-api/utils/errors"
+)
+
+type SourceRepository interface {
+	GetSourceByID(id string) (models.Source, error)
+	CreateNewSource(Source models.Source) error
+}
+
+type SourceRepositoryImplementation struct {
+	client *firestore.Client
+}
+
+func NewSourceRepository(client *firestore.Client) *SourceRepositoryImplementation {
+	return &SourceRepositoryImplementation{
+		client: client,
+	}
+}
+
+func (r *SourceRepositoryImplementation) GetSourceByID(id string) (models.Source, error) {
+	SourceCollection := r.client.Collection("sources")
+
+	SourceDoc, err := SourceCollection.Doc(id).Get(context.Background())
+
+	if err != nil {
+		wrapEr := error_utils.SourceRepositoryError{}
+		return models.Source{}, error_utils.CheckFirebaseError(err, id, &wrapEr)
+	}
+
+	var Source models.Source
+
+	if err = SourceDoc.DataTo(&Source); err != nil {
+		wrapErr := error_utils.SourceRepositoryError{}
+		logged_err := error_utils.FirestoreParsingError{DocID: Source.UID, StructName: "Source"}
+		wrapErr.Wrap(logged_err)
+		return models.Source{}, wrapErr
+	}
+
+	return Source, nil
+}
+
+func (r *SourceRepositoryImplementation) CreateNewSource(Source models.Source) error {
+	SourceCollection := r.client.Collection("sources")
+
+	_, err := SourceCollection.Doc(Source.UID).Create(context.Background(), Source)
+
+	if err != nil {
+		wrapErr := error_utils.SourceRepositoryError{}
+		return error_utils.CheckFirebaseError(err, Source.UID, &wrapErr)
+	}
+	return nil
+}

--- a/repository/source_repo.go
+++ b/repository/source_repo.go
@@ -46,9 +46,13 @@ func (r *SourceRepositoryImplementation) GetSourceByID(id string) (models.Source
 }
 
 func (r *SourceRepositoryImplementation) CreateNewSource(Source models.Source) error {
+
 	SourceCollection := r.client.Collection("sources")
 
 	userDocRef, _ := r.client.Collection("users").Doc(Source.OwnerId).Get(context.Background())
+
+	Source.NewCreationAtDate()
+	Source.NewUpdatedAtDate()
 
 	if userDocRef == nil {
 		wrapErr := error_utils.SourceRepositoryError{}

--- a/repository/source_repo.go
+++ b/repository/source_repo.go
@@ -12,6 +12,7 @@ type SourceRepository interface {
 	GetSourceByID(id string) (models.Source, error)
 	CreateNewSource(Source models.Source) error
 	UpdateNewSource(id string, Source models.Source) error
+	DeleteSource(id string) error
 }
 
 type SourceRepositoryImplementation struct {
@@ -82,6 +83,22 @@ func (r *SourceRepositoryImplementation) UpdateNewSource(source models.Source) e
 	if err != nil {
 		wrapErr := error_utils.SourceRepositoryError{}
 		return error_utils.CheckFirebaseError(err, source.UID, &wrapErr)
+	}
+	return nil
+}
+
+func (r *SourceRepositoryImplementation) DeleteSource(id string) error {
+	sourceDoc, err := getSourceDocSnapByID(id, r.client)
+
+	if err != nil {
+		wrapErr := error_utils.SourceRepositoryError{}
+		return error_utils.CheckFirebaseError(err, id, &wrapErr)
+	}
+
+	_, err = sourceDoc.Ref.Delete(context.Background())
+	if err != nil {
+		wrapErr := error_utils.SourceRepositoryError{}
+		return error_utils.CheckFirebaseError(err, id, &wrapErr)
 	}
 	return nil
 }

--- a/repository/source_repo.go
+++ b/repository/source_repo.go
@@ -11,7 +11,7 @@ import (
 type SourceRepository interface {
 	GetSourceByID(id string) (models.Source, error)
 	CreateNewSource(Source models.Source) error
-	UpdateNewSource(Source models.Source) error
+	UpdateSource(Source models.Source) error
 	DeleteSource(id string) error
 }
 
@@ -69,7 +69,7 @@ func (r *SourceRepositoryImplementation) CreateNewSource(Source models.Source) e
 	return nil
 }
 
-func (r *SourceRepositoryImplementation) UpdateNewSource(source models.Source) error {
+func (r *SourceRepositoryImplementation) UpdateSource(source models.Source) error {
 	source.NewUpdatedAtDate()
 
 	sourceDoc, err := getSourceDocSnapByID(source.UID, r.client)

--- a/repository/source_repo.go
+++ b/repository/source_repo.go
@@ -61,7 +61,10 @@ func (r *SourceRepositoryImplementation) CreateNewSource(Source models.Source) e
 		return wrapErr
 	}
 
-	_, err := SourceCollection.Doc(Source.UID).Create(context.Background(), Source)
+	docRef := SourceCollection.NewDoc()
+	Source.UID = docRef.ID
+
+	_, err := docRef.Set(context.Background(), Source)
 	if err != nil {
 		wrapErr := error_utils.SourceRepositoryError{}
 		return error_utils.CheckFirebaseError(err, Source.UID, &wrapErr)

--- a/repository/source_repo_test.go
+++ b/repository/source_repo_test.go
@@ -236,7 +236,7 @@ func TestSourceRepositoryImplementation_UpdateSource(t *testing.T) {
 				"firestoreClient": firestoreClient,
 			},
 			Args: test_utils.Args{
-				"source": &models.Source{UID: createdSourceUID, Name: "Update Source"},
+				"source": &models.Source{UID: createdSourceUID, Name: "Update Source", OwnerId: "0"},
 			},
 			WantErr:     false,
 			ExpectedErr: nil,

--- a/repository/source_repo_test.go
+++ b/repository/source_repo_test.go
@@ -290,7 +290,7 @@ func TestSourceRepositoryImplementation_UpdateSource(t *testing.T) {
 				client: testFirestoreClient.(*firestore.Client),
 			}
 			sourceTest := test_utils.GetArgByNameAndType(t, tt.Args, "source", new(models.Source)).(*models.Source)
-			err := r.UpdateNewSource(*sourceTest)
+			err := r.UpdateSource(*sourceTest)
 			if !tt.WantErr {
 				assert.NoError(t, err)
 			} else {

--- a/repository/source_repo_test.go
+++ b/repository/source_repo_test.go
@@ -386,7 +386,7 @@ func TestSourceRepositoryImplementation_DeleteSource(t *testing.T) {
 			}
 			sourceTestId := test_utils.GetArgByNameAndType(t, tt.Args, "id", "").(string)
 
-			err := r.DeleteSource(sourceTestId)
+			err := r.DeleteSource(sourceTestId, "0")
 			if !tt.WantErr {
 				assert.NoError(t, err)
 			} else {

--- a/repository/source_repo_test.go
+++ b/repository/source_repo_test.go
@@ -128,7 +128,6 @@ func TestSourceRepositoryImplementation_CreateNewSource(t *testing.T) {
 				}
 				test_utils.ClearFireStoreTest(firestoreClient, "Create", args)
 			}()
-
 		})
 	}
 	deleteTestUser(firestoreClient)
@@ -280,7 +279,7 @@ func TestSourceRepositoryImplementation_UpdateSource(t *testing.T) {
 				client: testFirestoreClient.(*firestore.Client),
 			}
 			sourceTest := test_utils.GetArgByNameAndType(t, tt.Args, "source", new(models.Source)).(*models.Source)
-			err := r.UpdateSource(*sourceTest)
+			_, err := r.UpdateSource(*sourceTest)
 			if !tt.WantErr {
 				assert.NoError(t, err)
 			} else {

--- a/repository/source_repo_test.go
+++ b/repository/source_repo_test.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"testing"
+	"time"
 
 	"cloud.google.com/go/firestore"
 	"github.com/AndresCRamos/midas-app-api/models"
@@ -27,9 +28,11 @@ func createTestSource(t *testing.T, firestoreClient *firestore.Client) {
 	}
 
 	err := userDuplicated.CreateNewSource(models.Source{
-		UID:     "0",
-		Name:    "Test Source",
-		OwnerId: "0",
+		UID:       "0",
+		Name:      "Test Source",
+		OwnerId:   "0",
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
 	})
 	if err != nil {
 		t.Fatalf("Cant connect to Firestore to create test source: %s", err.Error())
@@ -198,9 +201,11 @@ func TestSourceRepositoryImplementation_GetSourceByID(t *testing.T) {
 	}
 
 	searchSource := models.Source{
-		UID:     "0",
-		Name:    "Test Source",
-		OwnerId: "0",
+		UID:       "0",
+		Name:      "Test Source",
+		OwnerId:   "0",
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
 	}
 
 	for _, tt := range tests {
@@ -216,7 +221,7 @@ func TestSourceRepositoryImplementation_GetSourceByID(t *testing.T) {
 			res, err := r.GetSourceByID(sourceTestId)
 			if !tt.WantErr {
 				assert.NoError(t, err)
-				assert.Equal(t, searchSource, res)
+				checkEqualSource(t, searchSource, res)
 			} else {
 				assert.ErrorAs(t, err, &tt.ExpectedErr)
 			}
@@ -391,4 +396,12 @@ func TestSourceRepositoryImplementation_DeleteSource(t *testing.T) {
 		})
 	}
 	deleteTestUser(firestoreClient)
+}
+
+func checkEqualSource(t *testing.T, expected models.Source, got models.Source) {
+	assert.Equal(t, expected.UID, got.UID)
+	assert.Equal(t, expected.Name, got.Name)
+	assert.Equal(t, expected.Description, got.Description)
+	assert.WithinDuration(t, expected.CreatedAt, got.CreatedAt, 10*time.Second)
+	assert.WithinDuration(t, expected.UpdatedAt, got.UpdatedAt, 10*time.Second)
 }

--- a/repository/source_repo_test.go
+++ b/repository/source_repo_test.go
@@ -1,0 +1,183 @@
+package repository
+
+import (
+	"testing"
+
+	"cloud.google.com/go/firestore"
+	"github.com/AndresCRamos/midas-app-api/models"
+	error_utils "github.com/AndresCRamos/midas-app-api/utils/errors"
+	test_utils "github.com/AndresCRamos/midas-app-api/utils/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSourceRepositoryImplementation_CreateNewSource(t *testing.T) {
+
+	firestoreClient := test_utils.InitTestingFireStore(t)
+	firestoreClientFail := test_utils.InitTestingFireStoreFail(t)
+
+	dupSource := models.Source{
+		UID:  "0",
+		Name: "DupSource",
+	}
+
+	createDupSource := func(t *testing.T) {
+		rDuplicated := &SourceRepositoryImplementation{
+			client: firestoreClient,
+		}
+
+		err := rDuplicated.CreateNewSource(dupSource)
+		if err != nil {
+			t.Fatalf("Cant connect to Firestore to check for duplication test: %s", err.Error())
+		}
+	}
+
+	tests := []test_utils.TestCase{
+		{
+			Name: "Success",
+			Fields: test_utils.Fields{
+				"firestoreClient": firestoreClient,
+			},
+			Args: test_utils.Args{
+				"source": &models.Source{UID: "0", Name: "TestSource"},
+			},
+			WantErr:     false,
+			ExpectedErr: nil,
+			PreTest:     nil,
+		},
+		{
+			Name: "Fail to connect",
+			Fields: test_utils.Fields{
+				"firestoreClient": firestoreClientFail,
+			},
+			Args: test_utils.Args{
+				"source": &models.Source{},
+			},
+			WantErr:     true,
+			ExpectedErr: error_utils.FirebaseUnknownError{},
+			PreTest:     nil,
+		},
+		{
+			Name: "Duplicated source",
+			Fields: test_utils.Fields{
+				"firestoreClient": firestoreClient,
+			},
+			Args: test_utils.Args{
+				"source": &dupSource,
+			},
+			WantErr:     true,
+			ExpectedErr: error_utils.FirestoreAlreadyExistsError{DocID: dupSource.UID},
+			PreTest:     createDupSource,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			if tt.PreTest != nil {
+				tt.PreTest(t)
+			}
+			testFirestoreClient := test_utils.GetFieldByNameAndType(t, tt.Fields, "firestoreClient", new(firestore.Client))
+			r := &SourceRepositoryImplementation{
+				client: testFirestoreClient.(*firestore.Client),
+			}
+			sourceTest := test_utils.GetArgByNameAndType(t, tt.Args, "source", new(models.Source)).(*models.Source)
+			err := r.CreateNewSource(*sourceTest)
+			if !tt.WantErr {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorAs(t, err, &tt.ExpectedErr, "Expected error as: %s", tt.ExpectedErr.Error())
+			}
+			args := map[string]interface{}{
+				"Collection": "sources",
+				"id":         sourceTest.UID,
+			}
+			test_utils.ClearFireStoreTest(firestoreClient, "Create", args)
+		})
+
+	}
+}
+
+func TestSourceRepositoryImplementation_GetSourceByID(t *testing.T) {
+
+	firestoreClient := test_utils.InitTestingFireStore(t)
+	firestoreClientFail := test_utils.InitTestingFireStoreFail(t)
+
+	searchSource := models.Source{
+		UID:  "1",
+		Name: "SourceToSearch",
+	}
+
+	rSearch := SourceRepositoryImplementation{
+		client: firestoreClient,
+	}
+
+	testFields := test_utils.Fields{
+		"firestoreClient": firestoreClient,
+	}
+
+	testFieldsFail := test_utils.Fields{
+		"firestoreClient": firestoreClientFail,
+	}
+
+	err := rSearch.CreateNewSource(searchSource)
+	if err != nil {
+		t.Fatal("Cant create source to search")
+	}
+
+	tests := []test_utils.TestCase{
+		{
+			Name:   "Success",
+			Fields: testFields,
+			Args: test_utils.Args{
+				"id": searchSource.UID,
+			},
+			WantErr:     false,
+			ExpectedErr: nil,
+			PreTest:     nil,
+		},
+		{
+			Name:   "Fail to connect",
+			Fields: testFieldsFail,
+			Args: test_utils.Args{
+				"id": searchSource.UID,
+			},
+			WantErr:     true,
+			ExpectedErr: error_utils.FirebaseUnknownError{},
+			PreTest:     nil,
+		},
+		{
+			Name:   "Cant find",
+			Fields: testFields,
+			Args: test_utils.Args{
+				"id": "100",
+			},
+			WantErr:     true,
+			ExpectedErr: error_utils.FirestoreNotFoundError{DocID: "100"},
+			PreTest:     nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			if tt.PreTest != nil {
+				tt.PreTest(t)
+			}
+			r := &SourceRepositoryImplementation{
+				client: test_utils.GetFieldByNameAndType(t, tt.Fields, "firestoreClient", new(firestore.Client)).(*firestore.Client),
+			}
+			sourceTestId := test_utils.GetArgByNameAndType(t, tt.Args, "id", "").(string)
+
+			res, err := r.GetSourceByID(sourceTestId)
+			if !tt.WantErr {
+				assert.NoError(t, err)
+				assert.Equal(t, searchSource, res)
+			} else {
+				assert.ErrorAs(t, err, &tt.ExpectedErr)
+			}
+		})
+	}
+	args := test_utils.Args{
+		"Collection": "sources",
+		"id":         searchSource.UID,
+	}
+	defer test_utils.ClearFireStoreTest(firestoreClient, "Create", args)
+}

--- a/repository/source_repo_test.go
+++ b/repository/source_repo_test.go
@@ -216,5 +216,10 @@ func TestSourceRepositoryImplementation_GetSourceByID(t *testing.T) {
 			}
 		})
 	}
+	args := map[string]interface{}{
+		"Collection": "sources",
+		"id":         "0",
+	}
+	test_utils.ClearFireStoreTest(firestoreClient, "Create", args)
 	DeleteTestUser(firestoreClient)
 }

--- a/repository/user_repo.go
+++ b/repository/user_repo.go
@@ -30,7 +30,7 @@ func (r *UserRepositoryImplementation) GetUserByID(id string) (models.User, erro
 
 	if err != nil {
 		wrapEr := error_utils.UserRepositoryError{}
-		return models.User{}, error_utils.CheckFirebaseError(err, id, models.User{}, &wrapEr)
+		return models.User{}, error_utils.CheckFirebaseError(err, id, &wrapEr)
 	}
 
 	var user models.User
@@ -52,7 +52,7 @@ func (r *UserRepositoryImplementation) CreateNewUser(user models.User) error {
 
 	if err != nil {
 		wrapErr := error_utils.UserRepositoryError{}
-		return error_utils.CheckFirebaseError(err, user.UID, user, &wrapErr)
+		return error_utils.CheckFirebaseError(err, user.UID, &wrapErr)
 	}
 	return nil
 }

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -5,4 +5,5 @@ import "github.com/AndresCRamos/midas-app-api/cmd/server"
 func AddRoutes(server *server.Server) {
 	addMovementRoutes(server.FirestoreClient, server.Router)
 	addUserRoutes(server)
+	addSourceRoutes(server)
 }

--- a/routes/source_routes.go
+++ b/routes/source_routes.go
@@ -20,6 +20,7 @@ func addSourceRoutes(server *server.Server) {
 	sourceGroup := r.Group("/source")
 	sourceGroup.Use(middleware.VerifyToken(server.FirebaseAuthClient))
 	{
+		sourceGroup.GET("/", handler.GetSourcesByUser)
 		sourceGroup.POST("/", handler.CreateNewSource)
 		sourceGroup.GET("/:id", handler.GetSourceByID)
 		sourceGroup.PUT("/:id", handler.UpdateSource)

--- a/routes/source_routes.go
+++ b/routes/source_routes.go
@@ -1,0 +1,29 @@
+package routes
+
+import (
+	"github.com/AndresCRamos/midas-app-api/cmd/server"
+	"github.com/AndresCRamos/midas-app-api/handlers"
+	"github.com/AndresCRamos/midas-app-api/middleware"
+	"github.com/AndresCRamos/midas-app-api/repository"
+	"github.com/AndresCRamos/midas-app-api/services"
+)
+
+func addSourceRoutes(server *server.Server) {
+
+	client := server.FirestoreClient
+	r := server.Router
+
+	repo := repository.NewSourceRepository(client)
+	service := services.NewSourceService(repo)
+	handler := handlers.NewSourceHandler(service)
+
+	sourceGroup := r.Group("/source")
+	sourceGroup.Use(middleware.VerifyToken(server.FirebaseAuthClient))
+	{
+		sourceGroup.POST("/", handler.CreateNewSource)
+		sourceGroup.GET("/:id", handler.GetSourceByID)
+		sourceGroup.PUT("/:id", handler.UpdateSource)
+		sourceGroup.DELETE("/:id", handler.DeleteSource)
+	}
+
+}

--- a/services/source_service.go
+++ b/services/source_service.go
@@ -10,7 +10,7 @@ type SourceService interface {
 	CreateNewSource(Source models.Source) (models.Source, error)
 	GetSourceByID(id string, userID string) (models.Source, error)
 	UpdateSource(Source models.Source) (models.Source, error)
-	DeleteSource(id string) error
+	DeleteSource(id string, userID string) error
 }
 
 type sourceServiceImplementation struct {
@@ -49,8 +49,8 @@ func (s *sourceServiceImplementation) UpdateSource(source models.Source) (models
 	}
 	return source, nil
 }
-func (s *sourceServiceImplementation) DeleteSource(id string) error {
-	err := s.r.DeleteSource(id)
+func (s *sourceServiceImplementation) DeleteSource(id string, userID string) error {
+	err := s.r.DeleteSource(id, userID)
 	if err != nil {
 		sourceServiceErr := error_utils.SourceServiceError{Err: err, Method: "Delete"}
 		return sourceServiceErr

--- a/services/source_service.go
+++ b/services/source_service.go
@@ -9,7 +9,7 @@ import (
 type SourceService interface {
 	CreateNewSource(Source models.Source) error
 	GetSourceByID(id string) (models.Source, error)
-	UpdateNewSource(id string, Source models.Source) error
+	UpdateNewSource(Source models.Source) error
 	DeleteSource(id string) error
 }
 
@@ -41,8 +41,8 @@ func (s *sourceServiceImplementation) GetSourceByID(id string) (models.Source, e
 	return res, nil
 }
 
-func (s *sourceServiceImplementation) UpdateNewSource(id string, source models.Source) error {
-	err := s.r.UpdateNewSource(source)
+func (s *sourceServiceImplementation) UpdateNewSource(source models.Source) error {
+	err := s.r.UpdateSource(source)
 	if err != nil {
 		sourceServiceErr := error_utils.SourceServiceError{Err: err, Method: "Update"}
 		return sourceServiceErr

--- a/services/source_service.go
+++ b/services/source_service.go
@@ -3,12 +3,14 @@ package services
 import (
 	"github.com/AndresCRamos/midas-app-api/models"
 	"github.com/AndresCRamos/midas-app-api/repository"
+	util_models "github.com/AndresCRamos/midas-app-api/utils/api/models"
 	error_utils "github.com/AndresCRamos/midas-app-api/utils/errors"
 )
 
 type SourceService interface {
 	CreateNewSource(Source models.Source) (models.Source, error)
 	GetSourceByID(id string, userID string) (models.Source, error)
+	GetSourcesByUser(userID string, page int) (util_models.PaginatedSearch[models.Source], error)
 	UpdateSource(Source models.Source) (models.Source, error)
 	DeleteSource(id string, userID string) error
 }
@@ -28,6 +30,15 @@ func (s *sourceServiceImplementation) CreateNewSource(source models.Source) (mod
 	if err != nil {
 		sourceServiceErr := error_utils.SourceServiceError{Err: err, Method: "Create"}
 		return models.Source{}, sourceServiceErr
+	}
+	return source, nil
+}
+
+func (s *sourceServiceImplementation) GetSourcesByUser(userID string, page int) (util_models.PaginatedSearch[models.Source], error) {
+	source, err := s.r.GetSourcesByUser(userID, page)
+	if err != nil {
+		sourceServiceErr := error_utils.SourceServiceError{Err: err, Method: "List"}
+		return util_models.PaginatedSearch[models.Source]{}, sourceServiceErr
 	}
 	return source, nil
 }

--- a/services/source_service.go
+++ b/services/source_service.go
@@ -9,7 +9,7 @@ import (
 type SourceService interface {
 	CreateNewSource(Source models.Source) (models.Source, error)
 	GetSourceByID(id string) (models.Source, error)
-	UpdateSource(Source models.Source) error
+	UpdateSource(Source models.Source) (models.Source, error)
 	DeleteSource(id string) error
 }
 
@@ -41,13 +41,13 @@ func (s *sourceServiceImplementation) GetSourceByID(id string) (models.Source, e
 	return res, nil
 }
 
-func (s *sourceServiceImplementation) UpdateSource(source models.Source) error {
-	err := s.r.UpdateSource(source)
+func (s *sourceServiceImplementation) UpdateSource(source models.Source) (models.Source, error) {
+	source, err := s.r.UpdateSource(source)
 	if err != nil {
 		sourceServiceErr := error_utils.SourceServiceError{Err: err, Method: "Update"}
-		return sourceServiceErr
+		return models.Source{}, sourceServiceErr
 	}
-	return nil
+	return source, nil
 }
 func (s *sourceServiceImplementation) DeleteSource(id string) error {
 	err := s.r.DeleteSource(id)

--- a/services/source_service.go
+++ b/services/source_service.go
@@ -9,7 +9,7 @@ import (
 type SourceService interface {
 	CreateNewSource(Source models.Source) error
 	GetSourceByID(id string) (models.Source, error)
-	UpdateNewSource(Source models.Source) error
+	UpdateSource(Source models.Source) error
 	DeleteSource(id string) error
 }
 
@@ -41,7 +41,7 @@ func (s *sourceServiceImplementation) GetSourceByID(id string) (models.Source, e
 	return res, nil
 }
 
-func (s *sourceServiceImplementation) UpdateNewSource(source models.Source) error {
+func (s *sourceServiceImplementation) UpdateSource(source models.Source) error {
 	err := s.r.UpdateSource(source)
 	if err != nil {
 		sourceServiceErr := error_utils.SourceServiceError{Err: err, Method: "Update"}

--- a/services/source_service.go
+++ b/services/source_service.go
@@ -1,0 +1,59 @@
+package services
+
+import (
+	"github.com/AndresCRamos/midas-app-api/models"
+	"github.com/AndresCRamos/midas-app-api/repository"
+	error_utils "github.com/AndresCRamos/midas-app-api/utils/errors"
+)
+
+type SourceService interface {
+	CreateNewSource(Source models.Source) error
+	GetSourceByID(id string) (models.Source, error)
+	UpdateNewSource(id string, Source models.Source) error
+	DeleteSource(id string) error
+}
+
+type sourceServiceImplementation struct {
+	r repository.SourceRepository
+}
+
+func NewSourceService(r repository.SourceRepository) *sourceServiceImplementation {
+	return &sourceServiceImplementation{
+		r: r,
+	}
+}
+
+func (s *sourceServiceImplementation) CreateNewSource(source models.Source) error {
+	err := s.r.CreateNewSource(source)
+	if err != nil {
+		sourceServiceErr := error_utils.SourceServiceError{Err: err, Method: "Create"}
+		return sourceServiceErr
+	}
+	return nil
+}
+
+func (s *sourceServiceImplementation) GetSourceByID(id string) (models.Source, error) {
+	res, err := s.r.GetSourceByID(id)
+	if err != nil {
+		sourceServiceErr := error_utils.SourceServiceError{Err: err, Method: "Retrieve"}
+		return models.Source{}, sourceServiceErr
+	}
+	return res, nil
+}
+
+func (s *sourceServiceImplementation) UpdateNewSource(id string, source models.Source) error {
+	err := s.r.UpdateNewSource(source)
+	if err != nil {
+		sourceServiceErr := error_utils.SourceServiceError{Err: err, Method: "Update"}
+		return sourceServiceErr
+	}
+	return nil
+}
+func (s *sourceServiceImplementation) DeleteSource(id string) error {
+	err := s.r.DeleteSource(id)
+	if err != nil {
+		sourceServiceErr := error_utils.SourceServiceError{Err: err, Method: "Delete"}
+		return sourceServiceErr
+	}
+	return nil
+}

--- a/services/source_service.go
+++ b/services/source_service.go
@@ -8,7 +8,7 @@ import (
 
 type SourceService interface {
 	CreateNewSource(Source models.Source) (models.Source, error)
-	GetSourceByID(id string) (models.Source, error)
+	GetSourceByID(id string, userID string) (models.Source, error)
 	UpdateSource(Source models.Source) (models.Source, error)
 	DeleteSource(id string) error
 }
@@ -32,8 +32,8 @@ func (s *sourceServiceImplementation) CreateNewSource(source models.Source) (mod
 	return source, nil
 }
 
-func (s *sourceServiceImplementation) GetSourceByID(id string) (models.Source, error) {
-	res, err := s.r.GetSourceByID(id)
+func (s *sourceServiceImplementation) GetSourceByID(id string, userID string) (models.Source, error) {
+	res, err := s.r.GetSourceByID(id, userID)
 	if err != nil {
 		sourceServiceErr := error_utils.SourceServiceError{Err: err, Method: "Retrieve"}
 		return models.Source{}, sourceServiceErr

--- a/services/source_service.go
+++ b/services/source_service.go
@@ -7,7 +7,7 @@ import (
 )
 
 type SourceService interface {
-	CreateNewSource(Source models.Source) error
+	CreateNewSource(Source models.Source) (models.Source, error)
 	GetSourceByID(id string) (models.Source, error)
 	UpdateSource(Source models.Source) error
 	DeleteSource(id string) error
@@ -23,13 +23,13 @@ func NewSourceService(r repository.SourceRepository) *sourceServiceImplementatio
 	}
 }
 
-func (s *sourceServiceImplementation) CreateNewSource(source models.Source) error {
-	err := s.r.CreateNewSource(source)
+func (s *sourceServiceImplementation) CreateNewSource(source models.Source) (models.Source, error) {
+	source, err := s.r.CreateNewSource(source)
 	if err != nil {
 		sourceServiceErr := error_utils.SourceServiceError{Err: err, Method: "Create"}
-		return sourceServiceErr
+		return models.Source{}, sourceServiceErr
 	}
-	return nil
+	return source, nil
 }
 
 func (s *sourceServiceImplementation) GetSourceByID(id string) (models.Source, error) {

--- a/services/source_service_test.go
+++ b/services/source_service_test.go
@@ -1,0 +1,275 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/AndresCRamos/midas-app-api/models"
+	"github.com/AndresCRamos/midas-app-api/repository"
+	error_utils "github.com/AndresCRamos/midas-app-api/utils/errors"
+	test_utils "github.com/AndresCRamos/midas-app-api/utils/test"
+	"github.com/AndresCRamos/midas-app-api/utils/test/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_sourceServiceImplementation_CreateNewSource(t *testing.T) {
+
+	mockRepoMain := mocks.SourceRepositoryMock{}
+
+	fields := test_utils.Fields{
+		"mockRepo": mockRepoMain,
+	}
+
+	tests := []test_utils.TestCase{
+		{
+			Name:   "Success",
+			Fields: fields,
+			Args: test_utils.Args{
+				"source": &models.Source{Name: "Success"},
+			},
+			WantErr:     false,
+			ExpectedErr: nil,
+			PreTest:     nil,
+		},
+		{
+			Name:   "Fail to connect",
+			Fields: fields,
+			Args: test_utils.Args{
+				"source": &models.Source{Name: "CantConnect"},
+			},
+			WantErr:     true,
+			ExpectedErr: error_utils.FirebaseUnknownError{},
+			PreTest:     nil,
+		},
+		{
+			Name:   "Duplicated Source",
+			Fields: fields,
+			Args: test_utils.Args{
+				"source": &models.Source{Name: "Duplicated", UID: "0"},
+			},
+			WantErr:     true,
+			ExpectedErr: error_utils.FirestoreAlreadyExistsError{},
+			PreTest:     nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			if tt.PreTest != nil {
+				tt.PreTest(t)
+			}
+			// mockRepo := test_utils.GetFieldByNameAndType(t, tt.Fields, "mockRepo", new(repository.SourceRepository))
+			s := &sourceServiceImplementation{
+				r: mockRepoMain,
+			}
+			sourceTest := test_utils.GetArgByNameAndType(t, tt.Args, "source", new(models.Source)).(*models.Source)
+			err := s.CreateNewSource(*sourceTest)
+			if !tt.WantErr {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				assert.ErrorAs(t, err, &tt.ExpectedErr)
+			}
+		})
+
+	}
+}
+
+func Test_sourceServiceImplementation_GetSourceByID(t *testing.T) {
+
+	mockRepo := mocks.SourceRepositoryMock{}
+
+	fields := test_utils.Fields{
+		"mockRepo": mockRepo,
+	}
+
+	tests := []test_utils.TestCase{
+		{
+			Name:   "Success",
+			Fields: fields,
+			Args: test_utils.Args{
+				"id": "0",
+			},
+			WantErr:     false,
+			ExpectedErr: nil,
+			PreTest:     nil,
+		},
+		{
+			Name:   "Fail to connect",
+			Fields: fields,
+			Args: test_utils.Args{
+				"id": "1",
+			},
+			WantErr:     true,
+			ExpectedErr: error_utils.FirebaseUnknownError{},
+			PreTest:     nil,
+		},
+		{
+			Name:   "Not Found",
+			Fields: fields,
+			Args: test_utils.Args{
+				"id": "2",
+			},
+			WantErr:     true,
+			ExpectedErr: error_utils.FirestoreNotFoundError{},
+			PreTest:     nil,
+		},
+		{
+			Name:   "Parsing error",
+			Fields: fields,
+			Args: test_utils.Args{
+				"id": "3",
+			},
+			WantErr:     true,
+			ExpectedErr: error_utils.FirestoreParsingError{},
+			PreTest:     nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			if tt.PreTest != nil {
+				tt.PreTest(t)
+			}
+			mockRepo := test_utils.GetFieldByNameAndType(t, tt.Fields, "mockRepo", new(repository.SourceRepository))
+			s := &sourceServiceImplementation{
+				r: mockRepo.(repository.SourceRepository),
+			}
+			id := test_utils.GetArgByNameAndType(t, tt.Args, "id", "").(string)
+			got, err := s.GetSourceByID(id)
+			if !tt.WantErr {
+				assert.Equal(t, got, mocks.TestSource)
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				assert.ErrorAs(t, err, &tt.ExpectedErr)
+			}
+		})
+
+	}
+}
+
+func Test_sourceServiceImplementation_UpdateSource(t *testing.T) {
+
+	mockRepo := mocks.SourceRepositoryMock{}
+
+	fields := test_utils.Fields{
+		"mockRepo": mockRepo,
+	}
+
+	tests := []test_utils.TestCase{
+		{
+			Name:   "Success",
+			Fields: fields,
+			Args: test_utils.Args{
+				"source": &models.Source{Name: "Success", UID: "0"},
+			},
+			WantErr:     false,
+			ExpectedErr: nil,
+			PreTest:     nil,
+		},
+		{
+			Name:   "Fail to connect",
+			Fields: fields,
+			Args: test_utils.Args{
+				"source": &models.Source{Name: "Cant update", UID: "1"},
+			},
+			WantErr:     true,
+			ExpectedErr: error_utils.FirebaseUnknownError{},
+			PreTest:     nil,
+		},
+		{
+			Name:   "Cant find",
+			Fields: fields,
+			Args: test_utils.Args{
+				"source": &models.Source{Name: "Cant update", UID: "2"},
+			},
+			WantErr:     true,
+			ExpectedErr: error_utils.FirestoreNotFoundError{},
+			PreTest:     nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			if tt.PreTest != nil {
+				tt.PreTest(t)
+			}
+			mockRepo := test_utils.GetFieldByNameAndType(t, tt.Fields, "mockRepo", new(repository.SourceRepository))
+			s := &sourceServiceImplementation{
+				r: mockRepo.(repository.SourceRepository),
+			}
+			testSource := test_utils.GetArgByNameAndType(t, tt.Args, "source", new(models.Source)).(*models.Source)
+			err := s.UpdateNewSource(*testSource)
+			if !tt.WantErr {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				assert.ErrorAs(t, err, &tt.ExpectedErr)
+			}
+		})
+
+	}
+}
+
+func Test_sourceServiceImplementation_DeleteSource(t *testing.T) {
+
+	mockRepo := mocks.SourceRepositoryMock{}
+
+	fields := test_utils.Fields{
+		"mockRepo": mockRepo,
+	}
+
+	tests := []test_utils.TestCase{
+		{
+			Name:   "Success",
+			Fields: fields,
+			Args: test_utils.Args{
+				"id": "0",
+			},
+			WantErr:     false,
+			ExpectedErr: nil,
+			PreTest:     nil,
+		},
+		{
+			Name:   "Fail to connect",
+			Fields: fields,
+			Args: test_utils.Args{
+				"id": "1",
+			},
+			WantErr:     true,
+			ExpectedErr: error_utils.FirebaseUnknownError{},
+			PreTest:     nil,
+		},
+		{
+			Name:   "Cant find",
+			Fields: fields,
+			Args: test_utils.Args{
+				"id": "2",
+			},
+			WantErr:     true,
+			ExpectedErr: error_utils.FirestoreNotFoundError{},
+			PreTest:     nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			if tt.PreTest != nil {
+				tt.PreTest(t)
+			}
+			mockRepo := test_utils.GetFieldByNameAndType(t, tt.Fields, "mockRepo", new(repository.SourceRepository))
+			s := &sourceServiceImplementation{
+				r: mockRepo.(repository.SourceRepository),
+			}
+			deleteIDSource := test_utils.GetArgByNameAndType(t, tt.Args, "id", "").(string)
+			err := s.DeleteSource(deleteIDSource)
+			if !tt.WantErr {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				assert.ErrorAs(t, err, &tt.ExpectedErr)
+			}
+		})
+
+	}
+}

--- a/services/source_service_test.go
+++ b/services/source_service_test.go
@@ -13,10 +13,10 @@ import (
 
 func Test_sourceServiceImplementation_CreateNewSource(t *testing.T) {
 
-	mockRepoMain := mocks.SourceRepositoryMock{}
+	mockRepo := mocks.SourceRepositoryMock{}
 
 	fields := test_utils.Fields{
-		"mockRepo": mockRepoMain,
+		"mockRepo": mockRepo,
 	}
 
 	tests := []test_utils.TestCase{
@@ -57,9 +57,9 @@ func Test_sourceServiceImplementation_CreateNewSource(t *testing.T) {
 			if tt.PreTest != nil {
 				tt.PreTest(t)
 			}
-			// mockRepo := test_utils.GetFieldByNameAndType(t, tt.Fields, "mockRepo", new(repository.SourceRepository))
+			mockRepo := test_utils.GetFieldByNameAndType(t, tt.Fields, "mockRepo", new(repository.SourceRepository))
 			s := &sourceServiceImplementation{
-				r: mockRepoMain,
+				r: mockRepo.(repository.SourceRepository),
 			}
 			sourceTest := test_utils.GetArgByNameAndType(t, tt.Args, "source", new(models.Source)).(*models.Source)
 			err := s.CreateNewSource(*sourceTest)
@@ -199,7 +199,7 @@ func Test_sourceServiceImplementation_UpdateSource(t *testing.T) {
 				r: mockRepo.(repository.SourceRepository),
 			}
 			testSource := test_utils.GetArgByNameAndType(t, tt.Args, "source", new(models.Source)).(*models.Source)
-			err := s.UpdateNewSource(*testSource)
+			err := s.UpdateSource(*testSource)
 			if !tt.WantErr {
 				assert.NoError(t, err)
 			} else {

--- a/services/source_service_test.go
+++ b/services/source_service_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/AndresCRamos/midas-app-api/models"
 	"github.com/AndresCRamos/midas-app-api/repository"
+	util_models "github.com/AndresCRamos/midas-app-api/utils/api/models"
 	error_utils "github.com/AndresCRamos/midas-app-api/utils/errors"
 	test_utils "github.com/AndresCRamos/midas-app-api/utils/test"
 	"github.com/AndresCRamos/midas-app-api/utils/test/mocks"
@@ -65,6 +66,79 @@ func Test_sourceServiceImplementation_CreateNewSource(t *testing.T) {
 			_, err := s.CreateNewSource(*sourceTest)
 			if !tt.WantErr {
 				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				assert.ErrorAs(t, err, &tt.ExpectedErr)
+			}
+		})
+
+	}
+}
+
+func Test_sourceServiceImplementation_GetSourcesByUser(t *testing.T) {
+
+	mockRepo := mocks.SourceRepositoryMock{}
+
+	fields := test_utils.Fields{
+		"mockRepo": mockRepo,
+	}
+
+	tests := []test_utils.TestCase{
+		{
+			Name:   "Success",
+			Fields: fields,
+			Args: test_utils.Args{
+				"userID": "0",
+				"expectedData": util_models.PaginatedSearch[models.Source]{
+					CurrentPage: 1,
+					TotalData:   1,
+					PageSize:    1,
+					Data: []models.Source{
+						mocks.TestSource,
+					},
+				},
+			},
+			WantErr:     false,
+			ExpectedErr: nil,
+			PreTest:     nil,
+		},
+		{
+			Name:   "Fail to connect",
+			Fields: fields,
+			Args: test_utils.Args{
+				"userID": "1",
+			},
+			WantErr:     true,
+			ExpectedErr: error_utils.FirebaseUnknownError{},
+			PreTest:     nil,
+		},
+		{
+			Name:   "Not enough data",
+			Fields: fields,
+			Args: test_utils.Args{
+				"userID": "2",
+			},
+			WantErr:     true,
+			ExpectedErr: error_utils.SourceNotEnoughData{},
+			PreTest:     nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			if tt.PreTest != nil {
+				tt.PreTest(t)
+			}
+			mockRepo := test_utils.GetFieldByNameAndType(t, tt.Fields, "mockRepo", new(repository.SourceRepository))
+			s := &sourceServiceImplementation{
+				r: mockRepo.(repository.SourceRepository),
+			}
+			userId := test_utils.GetArgByNameAndType(t, tt.Args, "userID", "").(string)
+			got, err := s.GetSourcesByUser(userId, 1)
+			if !tt.WantErr {
+				expected := test_utils.GetArgByNameAndType(t, tt.Args, "expectedData", util_models.PaginatedSearch[models.Source]{})
+				assert.NoError(t, err)
+				assert.Equal(t, expected, got)
 			} else {
 				assert.Error(t, err)
 				assert.ErrorAs(t, err, &tt.ExpectedErr)

--- a/services/source_service_test.go
+++ b/services/source_service_test.go
@@ -62,7 +62,7 @@ func Test_sourceServiceImplementation_CreateNewSource(t *testing.T) {
 				r: mockRepo.(repository.SourceRepository),
 			}
 			sourceTest := test_utils.GetArgByNameAndType(t, tt.Args, "source", new(models.Source)).(*models.Source)
-			err := s.CreateNewSource(*sourceTest)
+			_, err := s.CreateNewSource(*sourceTest)
 			if !tt.WantErr {
 				assert.NoError(t, err)
 			} else {

--- a/services/source_service_test.go
+++ b/services/source_service_test.go
@@ -262,7 +262,7 @@ func Test_sourceServiceImplementation_DeleteSource(t *testing.T) {
 				r: mockRepo.(repository.SourceRepository),
 			}
 			deleteIDSource := test_utils.GetArgByNameAndType(t, tt.Args, "id", "").(string)
-			err := s.DeleteSource(deleteIDSource)
+			err := s.DeleteSource(deleteIDSource, "123")
 			if !tt.WantErr {
 				assert.NoError(t, err)
 			} else {

--- a/services/source_service_test.go
+++ b/services/source_service_test.go
@@ -135,7 +135,7 @@ func Test_sourceServiceImplementation_GetSourceByID(t *testing.T) {
 				r: mockRepo.(repository.SourceRepository),
 			}
 			id := test_utils.GetArgByNameAndType(t, tt.Args, "id", "").(string)
-			got, err := s.GetSourceByID(id)
+			got, err := s.GetSourceByID(id, "123")
 			if !tt.WantErr {
 				assert.Equal(t, got, mocks.TestSource)
 				assert.NoError(t, err)

--- a/services/source_service_test.go
+++ b/services/source_service_test.go
@@ -199,7 +199,7 @@ func Test_sourceServiceImplementation_UpdateSource(t *testing.T) {
 				r: mockRepo.(repository.SourceRepository),
 			}
 			testSource := test_utils.GetArgByNameAndType(t, tt.Args, "source", new(models.Source)).(*models.Source)
-			err := s.UpdateSource(*testSource)
+			_, err := s.UpdateSource(*testSource)
 			if !tt.WantErr {
 				assert.NoError(t, err)
 			} else {

--- a/utils/api/models/paginated.go
+++ b/utils/api/models/paginated.go
@@ -1,8 +1,30 @@
 package models
 
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	page_type_error = "page must be a number"
+)
+
 type PaginatedSearch[T any] struct {
 	CurrentPage int `json:"page"`
 	TotalData   int `json:"total"`
 	PageSize    int `json:"size"`
 	Data        []T `json:"data"`
+}
+
+type PaginatedTypeError struct{}
+
+func (pte PaginatedTypeError) Error() string {
+	return page_type_error
+}
+
+func (pte PaginatedTypeError) GetAPIError() (int, gin.H) {
+	return http.StatusBadRequest, gin.H{
+		"error": page_type_error,
+	}
 }

--- a/utils/api/models/paginated.go
+++ b/utils/api/models/paginated.go
@@ -1,0 +1,8 @@
+package models
+
+type PaginatedSearch[T any] struct {
+	CurrentPage int
+	TotalData   int
+	PageSize    int
+	Data        []T
+}

--- a/utils/api/models/paginated.go
+++ b/utils/api/models/paginated.go
@@ -1,8 +1,8 @@
 package models
 
 type PaginatedSearch[T any] struct {
-	CurrentPage int
-	TotalData   int
-	PageSize    int
-	Data        []T
+	CurrentPage int `json:"page"`
+	TotalData   int `json:"total"`
+	PageSize    int `json:"size"`
+	Data        []T `json:"data"`
 }

--- a/utils/errors/auth.go
+++ b/utils/errors/auth.go
@@ -1,6 +1,11 @@
 package errors
 
-import "fmt"
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
 
 const (
 	firebase_auth_error = "Failed to initialize Firebase Authentication: %s"
@@ -32,4 +37,28 @@ func (fac FirebaseAuthCantConnect) Error() string {
 
 func (fac FirebaseAuthCantConnect) Unwrap() error {
 	return nil
+}
+
+type EmptyToken struct{}
+
+func (e EmptyToken) GetAPIError() (int, gin.H) {
+	return http.StatusUnauthorized, gin.H{
+		"error": "Authorization token is empty",
+	}
+}
+
+type InvalidToken struct{}
+
+func (i InvalidToken) GetAPIError() (int, gin.H) {
+	return http.StatusUnauthorized, gin.H{
+		"error": "Token is invalid",
+	}
+}
+
+type CantGetUser struct{}
+
+func (cgu CantGetUser) GetAPIError() (int, gin.H) {
+	return http.StatusUnauthorized, gin.H{
+		"error": "Cant get user from token",
+	}
 }

--- a/utils/errors/source.go
+++ b/utils/errors/source.go
@@ -12,6 +12,7 @@ const (
 	SOURCE_NOT_FOUND      = "A source with id %s doesn't exists"
 	OWNER_NOT_FOUND       = "The source %s cant be created, because owner %s doesn't exists"
 	OWNER_CANT_CHANGE     = "The provided owner %s of source %s is not the current one"
+	SOURCE_NOT_OWNER      = "The user %s is not the owner of source %s"
 )
 
 const (
@@ -123,4 +124,19 @@ func (sco SourceCantChangeOwner) GetAPIError() (int, gin.H) {
 
 func (sco SourceCantChangeOwner) Error() string {
 	return fmt.Sprintf(OWNER_CANT_CHANGE, sco.OwnerID, sco.SourceID)
+}
+
+type SourceDifferentOwner struct {
+	SourceID string
+	OwnerID  string
+}
+
+func (sdo SourceDifferentOwner) GetAPIError() (int, gin.H) {
+	return http.StatusNotFound, gin.H{
+		"error": fmt.Sprintf(SOURCE_NOT_OWNER, sdo.OwnerID, sdo.SourceID),
+	}
+}
+
+func (sdo SourceDifferentOwner) Error() string {
+	return fmt.Sprintf(SOURCE_NOT_OWNER, sdo.OwnerID, sdo.SourceID)
 }

--- a/utils/errors/source.go
+++ b/utils/errors/source.go
@@ -1,0 +1,90 @@
+package errors
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	SOURCE_ALREADY_EXISTS = "A source with id %s already exists"
+	SOURCE_NOT_FOUND      = "A source with id %s doesn't exists"
+)
+
+const (
+	source_repository_error = "SourceRepository: %s"
+	source_service_error    = "SourceService: %s: %s"
+)
+
+// SourceRepositoryError struct
+type SourceRepositoryError struct {
+	Err error
+}
+
+func (ure SourceRepositoryError) Error() string {
+	return fmt.Sprintf(source_repository_error, ure.Err.Error())
+}
+
+func (ure *SourceRepositoryError) Wrap(err error) {
+	ure.Err = err
+}
+
+func (ure SourceRepositoryError) Unwrap() error {
+	return ure.Err
+}
+
+// SourceServiceError struct
+type SourceServiceError struct {
+	Method string
+	Err    error
+}
+
+func (use SourceServiceError) Error() string {
+	MethodMsg := ""
+	switch use.Method {
+	case "Create":
+		MethodMsg = "Cant create"
+	case "Retrieve":
+		MethodMsg = "Cant retrieve"
+	default:
+		MethodMsg = "Unknown method"
+	}
+	return fmt.Sprintf(source_service_error, MethodMsg, use.Err.Error())
+}
+
+func (use *SourceServiceError) Wrap(err error) {
+	use.Err = err
+}
+
+func (use SourceServiceError) Unwrap() error {
+	return use.Err
+}
+
+type SourceDuplicated struct {
+	SourceID string
+}
+
+func (ud SourceDuplicated) GetAPIError() (int, gin.H) {
+	return http.StatusBadRequest, gin.H{
+		"error": fmt.Sprintf(SOURCE_ALREADY_EXISTS, ud.SourceID),
+	}
+}
+
+func (ud SourceDuplicated) Error() string {
+	return fmt.Sprintf(SOURCE_ALREADY_EXISTS, ud.SourceID)
+}
+
+type SourceNotFound struct {
+	SourceID string
+}
+
+func (ud SourceNotFound) GetAPIError() (int, gin.H) {
+	return http.StatusNotFound, gin.H{
+		"error": fmt.Sprintf(SOURCE_NOT_FOUND, ud.SourceID),
+	}
+}
+
+func (ud SourceNotFound) Error() string {
+	return fmt.Sprintf(SOURCE_NOT_FOUND, ud.SourceID)
+}

--- a/utils/errors/source.go
+++ b/utils/errors/source.go
@@ -48,6 +48,10 @@ func (sse SourceServiceError) Error() string {
 		MethodMsg = "Cant create"
 	case "Retrieve":
 		MethodMsg = "Cant retrieve"
+	case "Update":
+		MethodMsg = "Cant update"
+	case "Delete":
+		MethodMsg = "Cant delete"
 	default:
 		MethodMsg = "Unknown method"
 	}

--- a/utils/errors/source.go
+++ b/utils/errors/source.go
@@ -10,6 +10,7 @@ import (
 const (
 	SOURCE_ALREADY_EXISTS = "A source with id %s already exists"
 	SOURCE_NOT_FOUND      = "A source with id %s doesn't exists"
+	OWNER_NOT_FOUND       = "The source %s cant be created, because owner %s doesn't exists"
 )
 
 const (
@@ -22,16 +23,16 @@ type SourceRepositoryError struct {
 	Err error
 }
 
-func (ure SourceRepositoryError) Error() string {
-	return fmt.Sprintf(source_repository_error, ure.Err.Error())
+func (sre SourceRepositoryError) Error() string {
+	return fmt.Sprintf(source_repository_error, sre.Err.Error())
 }
 
-func (ure *SourceRepositoryError) Wrap(err error) {
-	ure.Err = err
+func (sre *SourceRepositoryError) Wrap(err error) {
+	sre.Err = err
 }
 
-func (ure SourceRepositoryError) Unwrap() error {
-	return ure.Err
+func (sre SourceRepositoryError) Unwrap() error {
+	return sre.Err
 }
 
 // SourceServiceError struct
@@ -40,9 +41,9 @@ type SourceServiceError struct {
 	Err    error
 }
 
-func (use SourceServiceError) Error() string {
+func (sse SourceServiceError) Error() string {
 	MethodMsg := ""
-	switch use.Method {
+	switch sse.Method {
 	case "Create":
 		MethodMsg = "Cant create"
 	case "Retrieve":
@@ -50,41 +51,56 @@ func (use SourceServiceError) Error() string {
 	default:
 		MethodMsg = "Unknown method"
 	}
-	return fmt.Sprintf(source_service_error, MethodMsg, use.Err.Error())
+	return fmt.Sprintf(source_service_error, MethodMsg, sse.Err.Error())
 }
 
-func (use *SourceServiceError) Wrap(err error) {
-	use.Err = err
+func (sse *SourceServiceError) Wrap(err error) {
+	sse.Err = err
 }
 
-func (use SourceServiceError) Unwrap() error {
-	return use.Err
+func (sse SourceServiceError) Unwrap() error {
+	return sse.Err
 }
 
 type SourceDuplicated struct {
 	SourceID string
 }
 
-func (ud SourceDuplicated) GetAPIError() (int, gin.H) {
+func (sd SourceDuplicated) GetAPIError() (int, gin.H) {
 	return http.StatusBadRequest, gin.H{
-		"error": fmt.Sprintf(SOURCE_ALREADY_EXISTS, ud.SourceID),
+		"error": fmt.Sprintf(SOURCE_ALREADY_EXISTS, sd.SourceID),
 	}
 }
 
-func (ud SourceDuplicated) Error() string {
-	return fmt.Sprintf(SOURCE_ALREADY_EXISTS, ud.SourceID)
+func (sd SourceDuplicated) Error() string {
+	return fmt.Sprintf(SOURCE_ALREADY_EXISTS, sd.SourceID)
 }
 
 type SourceNotFound struct {
 	SourceID string
 }
 
-func (ud SourceNotFound) GetAPIError() (int, gin.H) {
+func (snf SourceNotFound) GetAPIError() (int, gin.H) {
 	return http.StatusNotFound, gin.H{
-		"error": fmt.Sprintf(SOURCE_NOT_FOUND, ud.SourceID),
+		"error": fmt.Sprintf(SOURCE_NOT_FOUND, snf.SourceID),
 	}
 }
 
-func (ud SourceNotFound) Error() string {
-	return fmt.Sprintf(SOURCE_NOT_FOUND, ud.SourceID)
+func (snf SourceNotFound) Error() string {
+	return fmt.Sprintf(SOURCE_NOT_FOUND, snf.SourceID)
+}
+
+type SourceOwnerNotFound struct {
+	SourceID string
+	OwnerId  string
+}
+
+func (onf SourceOwnerNotFound) GetAPIError() (int, gin.H) {
+	return http.StatusNotFound, gin.H{
+		"error": fmt.Sprintf(OWNER_NOT_FOUND, onf.SourceID, onf.OwnerId),
+	}
+}
+
+func (onf SourceOwnerNotFound) Error() string {
+	return fmt.Sprintf(OWNER_NOT_FOUND, onf.SourceID, onf.OwnerId)
 }

--- a/utils/errors/source.go
+++ b/utils/errors/source.go
@@ -11,6 +11,7 @@ const (
 	SOURCE_ALREADY_EXISTS = "A source with id %s already exists"
 	SOURCE_NOT_FOUND      = "A source with id %s doesn't exists"
 	OWNER_NOT_FOUND       = "The source %s cant be created, because owner %s doesn't exists"
+	OWNER_CANT_CHANGE     = "The provided owner %s of source %s is not the current one"
 )
 
 const (
@@ -107,4 +108,19 @@ func (onf SourceOwnerNotFound) GetAPIError() (int, gin.H) {
 
 func (onf SourceOwnerNotFound) Error() string {
 	return fmt.Sprintf(OWNER_NOT_FOUND, onf.SourceID, onf.OwnerId)
+}
+
+type SourceCantChangeOwner struct {
+	SourceID string
+	OwnerID  string
+}
+
+func (sco SourceCantChangeOwner) GetAPIError() (int, gin.H) {
+	return http.StatusNotFound, gin.H{
+		"error": fmt.Sprintf(OWNER_CANT_CHANGE, sco.OwnerID, sco.SourceID),
+	}
+}
+
+func (sco SourceCantChangeOwner) Error() string {
+	return fmt.Sprintf(OWNER_CANT_CHANGE, sco.OwnerID, sco.SourceID)
 }

--- a/utils/errors/source.go
+++ b/utils/errors/source.go
@@ -8,11 +8,12 @@ import (
 )
 
 const (
-	SOURCE_ALREADY_EXISTS = "A source with id %s already exists"
-	SOURCE_NOT_FOUND      = "A source with id %s doesn't exists"
-	OWNER_NOT_FOUND       = "The source %s cant be created, because owner %s doesn't exists"
-	OWNER_CANT_CHANGE     = "The provided owner %s of source %s is not the current one"
-	SOURCE_NOT_OWNER      = "The user %s is not the owner of source %s"
+	SOURCE_ALREADY_EXISTS  = "A source with id %s already exists"
+	SOURCE_NOT_FOUND       = "A source with id %s doesn't exists"
+	OWNER_NOT_FOUND        = "The source %s cant be created, because owner %s doesn't exists"
+	OWNER_CANT_CHANGE      = "The provided owner %s of source %s is not the current one"
+	SOURCE_NOT_OWNER       = "The user %s is not the owner of source %s"
+	SOURCE_NOT_ENOUGH_DATA = "Requested source page does not exists"
 )
 
 const (
@@ -139,4 +140,16 @@ func (sdo SourceDifferentOwner) GetAPIError() (int, gin.H) {
 
 func (sdo SourceDifferentOwner) Error() string {
 	return fmt.Sprintf(SOURCE_NOT_OWNER, sdo.OwnerID, sdo.SourceID)
+}
+
+type SourceNotEnoughData struct{}
+
+func (sne SourceNotEnoughData) GetAPIError() (int, gin.H) {
+	return http.StatusNotFound, gin.H{
+		"error": SOURCE_NOT_ENOUGH_DATA,
+	}
+}
+
+func (sne SourceNotEnoughData) Error() string {
+	return SOURCE_NOT_ENOUGH_DATA
 }

--- a/utils/errors/source.go
+++ b/utils/errors/source.go
@@ -51,6 +51,8 @@ func (sse SourceServiceError) Error() string {
 		MethodMsg = "Cant create"
 	case "Retrieve":
 		MethodMsg = "Cant retrieve"
+	case "List":
+		MethodMsg = "Cant get list"
 	case "Update":
 		MethodMsg = "Cant update"
 	case "Delete":

--- a/utils/errors/utils.go
+++ b/utils/errors/utils.go
@@ -5,13 +5,12 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/AndresCRamos/midas-app-api/models"
 	"github.com/go-playground/validator/v10"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
-func CheckFirebaseError(err error, id string, user models.User, wrapper ErrorWrapper) error {
+func CheckFirebaseError(err error, id string, wrapper ErrorWrapper) error {
 
 	statusErrCode := status.Code(err)
 

--- a/utils/errors/utils.go
+++ b/utils/errors/utils.go
@@ -14,7 +14,7 @@ func CheckFirebaseError(err error, id string, wrapper ErrorWrapper) error {
 
 	statusErrCode := status.Code(err)
 
-	if statusErrCode == codes.NotFound {
+	if CheckFirebaseNotFound(err) {
 		logged_err := FirestoreNotFoundError{DocID: id}
 		wrapper.Wrap(logged_err)
 		return wrapper
@@ -43,6 +43,10 @@ func CheckFirebaseError(err error, id string, wrapper ErrorWrapper) error {
 
 	wrapper.Wrap(FirebaseUnknownError{})
 	return wrapper
+}
+
+func CheckFirebaseNotFound(err error) bool {
+	return status.Code(err) == codes.NotFound
 }
 
 func parseBindingErrors(errs ...error) []string {

--- a/utils/errors/utils.go
+++ b/utils/errors/utils.go
@@ -127,7 +127,7 @@ func getNotFoundByType(typeName string, id string) APIError {
 	case "user":
 		return UserNotFound{UserID: id}
 	case "source":
-		return SourceDuplicated{SourceID: id}
+		return SourceNotFound{SourceID: id}
 	}
 	return APIUnknown{}
 }

--- a/utils/errors/utils.go
+++ b/utils/errors/utils.go
@@ -118,8 +118,9 @@ func CheckServiceErrors(id string, err error, typeName string) APIError {
 
 func checkSourceServiceErrors(err error) APIError {
 	sourceNotFoundOwner := &SourceOwnerNotFound{}
+	sourceCantChangeOwner := &SourceCantChangeOwner{}
 
-	if errors.As(err, sourceNotFoundOwner) {
+	if errors.As(err, sourceNotFoundOwner) || errors.As(err, sourceCantChangeOwner) {
 		rootErr := getRootErr(err)
 		apiErr, ok := rootErr.(APIError)
 		if ok {

--- a/utils/errors/utils.go
+++ b/utils/errors/utils.go
@@ -117,10 +117,9 @@ func CheckServiceErrors(id string, err error, typeName string) APIError {
 }
 
 func checkSourceServiceErrors(err error) APIError {
-	sourceNotFoundOwner := &SourceOwnerNotFound{}
-	sourceCantChangeOwner := &SourceCantChangeOwner{}
+	var apiErr APIError
 
-	if errors.As(err, sourceNotFoundOwner) || errors.As(err, sourceCantChangeOwner) {
+	if errors.As(err, &apiErr) {
 		rootErr := getRootErr(err)
 		apiErr, ok := rootErr.(APIError)
 		if ok {

--- a/utils/test/mocks/source_repo.go
+++ b/utils/test/mocks/source_repo.go
@@ -7,19 +7,19 @@ import (
 
 type SourceRepositoryMock struct{}
 
-func (r SourceRepositoryMock) CreateNewSource(user models.Source) error {
+func (r SourceRepositoryMock) CreateNewSource(source models.Source) error {
 	wrapper := error_const.SourceRepositoryError{}
-	switch user.Name {
+	switch source.Name {
 	case "Success":
 		return nil
 	case "CantConnect":
 		wrapper.Wrap(error_const.FirebaseUnknownError{})
 		return wrapper
 	case "Duplicated":
-		wrapper.Wrap(error_const.FirestoreAlreadyExistsError{DocID: user.UID})
+		wrapper.Wrap(error_const.FirestoreAlreadyExistsError{DocID: source.UID})
 		return wrapper
 	default:
-		return error_const.TestInvalidTestCaseError{Param: user.Name}
+		return error_const.TestInvalidTestCaseError{Param: source.Name}
 	}
 }
 
@@ -44,40 +44,41 @@ func (r SourceRepositoryMock) GetSourceByID(id string) (models.Source, error) {
 	}
 }
 
-func (r SourceRepositoryMock) UpdateSource(id string) (models.Source, error) {
+func (r SourceRepositoryMock) UpdateSource(source models.Source) error {
+	id := source.UID
 	wrapper := error_const.SourceRepositoryError{}
 	switch id {
 	case "0":
-		return TestSource, nil
+		return nil
 	case "1":
 		wrapper.Wrap(error_const.FirebaseUnknownError{})
-		return models.Source{}, wrapper
+		return wrapper
 	case "2":
 		wrapper.Wrap(error_const.FirestoreNotFoundError{DocID: id})
-		return models.Source{}, wrapper
+		return wrapper
 	case "3":
 		wrapper.Wrap(error_const.FirestoreParsingError{DocID: id, StructName: "user"})
-		return models.Source{}, wrapper
+		return wrapper
 	default:
-		return models.Source{}, error_const.TestInvalidTestCaseError{Param: id}
+		return error_const.TestInvalidTestCaseError{Param: id}
 	}
 }
 
-func (r SourceRepositoryMock) DeleteSource(id string) (models.Source, error) {
+func (r SourceRepositoryMock) DeleteSource(id string) error {
 	wrapper := error_const.SourceRepositoryError{}
 	switch id {
 	case "0":
-		return TestSource, nil
+		return nil
 	case "1":
 		wrapper.Wrap(error_const.FirebaseUnknownError{})
-		return models.Source{}, wrapper
+		return wrapper
 	case "2":
 		wrapper.Wrap(error_const.FirestoreNotFoundError{DocID: id})
-		return models.Source{}, wrapper
+		return wrapper
 	case "3":
 		wrapper.Wrap(error_const.FirestoreParsingError{DocID: id, StructName: "user"})
-		return models.Source{}, wrapper
+		return wrapper
 	default:
-		return models.Source{}, error_const.TestInvalidTestCaseError{Param: id}
+		return error_const.TestInvalidTestCaseError{Param: id}
 	}
 }

--- a/utils/test/mocks/source_repo.go
+++ b/utils/test/mocks/source_repo.go
@@ -1,0 +1,83 @@
+package mocks
+
+import (
+	"github.com/AndresCRamos/midas-app-api/models"
+	error_const "github.com/AndresCRamos/midas-app-api/utils/errors"
+)
+
+type SourceRepositoryMock struct{}
+
+func (r SourceRepositoryMock) CreateNewSource(user models.Source) error {
+	wrapper := error_const.SourceRepositoryError{}
+	switch user.Name {
+	case "Success":
+		return nil
+	case "CantConnect":
+		wrapper.Wrap(error_const.FirebaseUnknownError{})
+		return wrapper
+	case "Duplicated":
+		wrapper.Wrap(error_const.FirestoreAlreadyExistsError{DocID: user.UID})
+		return wrapper
+	default:
+		return error_const.TestInvalidTestCaseError{Param: user.Name}
+	}
+}
+
+var TestSource = models.Source{UID: "0", Name: "TEST_SOURCE"}
+
+func (r SourceRepositoryMock) GetSourceByID(id string) (models.Source, error) {
+	wrapper := error_const.SourceRepositoryError{}
+	switch id {
+	case "0":
+		return TestSource, nil
+	case "1":
+		wrapper.Wrap(error_const.FirebaseUnknownError{})
+		return models.Source{}, wrapper
+	case "2":
+		wrapper.Wrap(error_const.FirestoreNotFoundError{DocID: id})
+		return models.Source{}, wrapper
+	case "3":
+		wrapper.Wrap(error_const.FirestoreParsingError{DocID: id, StructName: "user"})
+		return models.Source{}, wrapper
+	default:
+		return models.Source{}, error_const.TestInvalidTestCaseError{Param: id}
+	}
+}
+
+func (r SourceRepositoryMock) UpdateSource(id string) (models.Source, error) {
+	wrapper := error_const.SourceRepositoryError{}
+	switch id {
+	case "0":
+		return TestSource, nil
+	case "1":
+		wrapper.Wrap(error_const.FirebaseUnknownError{})
+		return models.Source{}, wrapper
+	case "2":
+		wrapper.Wrap(error_const.FirestoreNotFoundError{DocID: id})
+		return models.Source{}, wrapper
+	case "3":
+		wrapper.Wrap(error_const.FirestoreParsingError{DocID: id, StructName: "user"})
+		return models.Source{}, wrapper
+	default:
+		return models.Source{}, error_const.TestInvalidTestCaseError{Param: id}
+	}
+}
+
+func (r SourceRepositoryMock) DeleteSource(id string) (models.Source, error) {
+	wrapper := error_const.SourceRepositoryError{}
+	switch id {
+	case "0":
+		return TestSource, nil
+	case "1":
+		wrapper.Wrap(error_const.FirebaseUnknownError{})
+		return models.Source{}, wrapper
+	case "2":
+		wrapper.Wrap(error_const.FirestoreNotFoundError{DocID: id})
+		return models.Source{}, wrapper
+	case "3":
+		wrapper.Wrap(error_const.FirestoreParsingError{DocID: id, StructName: "user"})
+		return models.Source{}, wrapper
+	default:
+		return models.Source{}, error_const.TestInvalidTestCaseError{Param: id}
+	}
+}

--- a/utils/test/mocks/source_repo.go
+++ b/utils/test/mocks/source_repo.go
@@ -37,7 +37,7 @@ func (r SourceRepositoryMock) GetSourceByID(id string) (models.Source, error) {
 		wrapper.Wrap(error_const.FirestoreNotFoundError{DocID: id})
 		return models.Source{}, wrapper
 	case "3":
-		wrapper.Wrap(error_const.FirestoreParsingError{DocID: id, StructName: "user"})
+		wrapper.Wrap(error_const.FirestoreParsingError{DocID: id, StructName: "source"})
 		return models.Source{}, wrapper
 	default:
 		return models.Source{}, error_const.TestInvalidTestCaseError{Param: id}
@@ -57,7 +57,7 @@ func (r SourceRepositoryMock) UpdateSource(source models.Source) error {
 		wrapper.Wrap(error_const.FirestoreNotFoundError{DocID: id})
 		return wrapper
 	case "3":
-		wrapper.Wrap(error_const.FirestoreParsingError{DocID: id, StructName: "user"})
+		wrapper.Wrap(error_const.FirestoreParsingError{DocID: id, StructName: "source"})
 		return wrapper
 	default:
 		return error_const.TestInvalidTestCaseError{Param: id}
@@ -76,7 +76,7 @@ func (r SourceRepositoryMock) DeleteSource(id string) error {
 		wrapper.Wrap(error_const.FirestoreNotFoundError{DocID: id})
 		return wrapper
 	case "3":
-		wrapper.Wrap(error_const.FirestoreParsingError{DocID: id, StructName: "user"})
+		wrapper.Wrap(error_const.FirestoreParsingError{DocID: id, StructName: "source"})
 		return wrapper
 	default:
 		return error_const.TestInvalidTestCaseError{Param: id}

--- a/utils/test/mocks/source_repo.go
+++ b/utils/test/mocks/source_repo.go
@@ -7,19 +7,19 @@ import (
 
 type SourceRepositoryMock struct{}
 
-func (r SourceRepositoryMock) CreateNewSource(source models.Source) error {
+func (r SourceRepositoryMock) CreateNewSource(source models.Source) (models.Source, error) {
 	wrapper := error_const.SourceRepositoryError{}
 	switch source.Name {
 	case "Success":
-		return nil
+		return source, nil
 	case "CantConnect":
 		wrapper.Wrap(error_const.FirebaseUnknownError{})
-		return wrapper
+		return models.Source{}, wrapper
 	case "Duplicated":
 		wrapper.Wrap(error_const.FirestoreAlreadyExistsError{DocID: source.UID})
-		return wrapper
+		return models.Source{}, wrapper
 	default:
-		return error_const.TestInvalidTestCaseError{Param: source.Name}
+		return models.Source{}, error_const.TestInvalidTestCaseError{Param: source.Name}
 	}
 }
 
@@ -44,23 +44,23 @@ func (r SourceRepositoryMock) GetSourceByID(id string) (models.Source, error) {
 	}
 }
 
-func (r SourceRepositoryMock) UpdateSource(source models.Source) error {
+func (r SourceRepositoryMock) UpdateSource(source models.Source) (models.Source, error) {
 	id := source.UID
 	wrapper := error_const.SourceRepositoryError{}
 	switch id {
 	case "0":
-		return nil
+		return source, nil
 	case "1":
 		wrapper.Wrap(error_const.FirebaseUnknownError{})
-		return wrapper
+		return models.Source{}, wrapper
 	case "2":
 		wrapper.Wrap(error_const.FirestoreNotFoundError{DocID: id})
-		return wrapper
+		return models.Source{}, wrapper
 	case "3":
 		wrapper.Wrap(error_const.FirestoreParsingError{DocID: id, StructName: "source"})
-		return wrapper
+		return models.Source{}, wrapper
 	default:
-		return error_const.TestInvalidTestCaseError{Param: id}
+		return models.Source{}, error_const.TestInvalidTestCaseError{Param: id}
 	}
 }
 

--- a/utils/test/mocks/source_repo.go
+++ b/utils/test/mocks/source_repo.go
@@ -25,6 +25,7 @@ func (r SourceRepositoryMock) CreateNewSource(source models.Source) (models.Sour
 }
 
 var TestSource = models.Source{UID: "0", Name: "TEST_SOURCE"}
+var TestSourceRetrieve = models.SourceRetrieve{UID: "0", Name: "TEST_SOURCE"}
 
 func (r SourceRepositoryMock) GetSourceByID(id string, user string) (models.Source, error) {
 	wrapper := error_const.SourceRepositoryError{}

--- a/utils/test/mocks/source_repo.go
+++ b/utils/test/mocks/source_repo.go
@@ -64,7 +64,7 @@ func (r SourceRepositoryMock) UpdateSource(source models.Source) (models.Source,
 	}
 }
 
-func (r SourceRepositoryMock) DeleteSource(id string) error {
+func (r SourceRepositoryMock) DeleteSource(id string, userID string) error {
 	wrapper := error_const.SourceRepositoryError{}
 	switch id {
 	case "0":

--- a/utils/test/mocks/source_repo.go
+++ b/utils/test/mocks/source_repo.go
@@ -2,6 +2,7 @@ package mocks
 
 import (
 	"github.com/AndresCRamos/midas-app-api/models"
+	util_models "github.com/AndresCRamos/midas-app-api/utils/api/models"
 	error_const "github.com/AndresCRamos/midas-app-api/utils/errors"
 )
 
@@ -41,6 +42,29 @@ func (r SourceRepositoryMock) GetSourceByID(id string, user string) (models.Sour
 		return models.Source{}, wrapper
 	default:
 		return models.Source{}, error_const.TestInvalidTestCaseError{Param: id}
+	}
+}
+
+func (r SourceRepositoryMock) GetSourcesByUser(userID string, page int) (util_models.PaginatedSearch[models.Source], error) {
+	wrapper := error_const.SourceRepositoryError{}
+	switch userID {
+	case "0":
+		return util_models.PaginatedSearch[models.Source]{
+			CurrentPage: page,
+			TotalData:   1,
+			PageSize:    1,
+			Data: []models.Source{
+				TestSource,
+			},
+		}, nil
+	case "1":
+		wrapper.Wrap(error_const.FirebaseUnknownError{})
+		return util_models.PaginatedSearch[models.Source]{}, wrapper
+	case "2":
+		wrapper.Wrap(error_const.SourceNotEnoughData{})
+		return util_models.PaginatedSearch[models.Source]{}, wrapper
+	default:
+		return util_models.PaginatedSearch[models.Source]{}, error_const.TestInvalidTestCaseError{Param: userID}
 	}
 }
 

--- a/utils/test/mocks/source_repo.go
+++ b/utils/test/mocks/source_repo.go
@@ -25,7 +25,7 @@ func (r SourceRepositoryMock) CreateNewSource(source models.Source) (models.Sour
 
 var TestSource = models.Source{UID: "0", Name: "TEST_SOURCE"}
 
-func (r SourceRepositoryMock) GetSourceByID(id string) (models.Source, error) {
+func (r SourceRepositoryMock) GetSourceByID(id string, user string) (models.Source, error) {
 	wrapper := error_const.SourceRepositoryError{}
 	switch id {
 	case "0":

--- a/utils/test/mocks/source_service.go
+++ b/utils/test/mocks/source_service.go
@@ -48,6 +48,10 @@ func (r SourceServiceMock) GetSourceByID(id string, userId string) (models.Sourc
 		RepoWrapper.Wrap(error_const.FirestoreParsingError{DocID: id, StructName: "source"})
 		ServiceWrapper.Wrap(RepoWrapper)
 		return models.Source{}, ServiceWrapper
+	case "4":
+		RepoWrapper.Wrap(error_const.SourceDifferentOwner{SourceID: id, OwnerID: userId})
+		ServiceWrapper.Wrap(RepoWrapper)
+		return models.Source{}, ServiceWrapper
 	default:
 		return models.Source{}, error_const.TestInvalidTestCaseError{Param: id}
 	}
@@ -73,7 +77,7 @@ func (r SourceServiceMock) UpdateSource(source models.Source) (models.Source, er
 		ServiceWrapper.Wrap(RepoWrapper)
 		return models.Source{}, ServiceWrapper
 	case "4":
-		RepoWrapper.Wrap(error_const.SourceCantChangeOwner{SourceID: id, OwnerID: source.OwnerId})
+		RepoWrapper.Wrap(error_const.SourceDifferentOwner{SourceID: id, OwnerID: source.OwnerId})
 		ServiceWrapper.Wrap(RepoWrapper)
 		return models.Source{}, ServiceWrapper
 	default:

--- a/utils/test/mocks/source_service.go
+++ b/utils/test/mocks/source_service.go
@@ -85,7 +85,7 @@ func (r SourceServiceMock) UpdateSource(source models.Source) (models.Source, er
 	}
 }
 
-func (r SourceServiceMock) DeleteSource(id string) error {
+func (r SourceServiceMock) DeleteSource(id string, userID string) error {
 	ServiceWrapper := error_const.SourceRepositoryError{}
 	RepoWrapper := error_const.SourceServiceError{}
 	switch id {
@@ -101,6 +101,10 @@ func (r SourceServiceMock) DeleteSource(id string) error {
 		return ServiceWrapper
 	case "3":
 		RepoWrapper.Wrap(error_const.FirestoreParsingError{DocID: id, StructName: "source"})
+		ServiceWrapper.Wrap(RepoWrapper)
+		return ServiceWrapper
+	case "4":
+		RepoWrapper.Wrap(error_const.SourceDifferentOwner{SourceID: id, OwnerID: userID})
 		ServiceWrapper.Wrap(RepoWrapper)
 		return ServiceWrapper
 	default:

--- a/utils/test/mocks/source_service.go
+++ b/utils/test/mocks/source_service.go
@@ -7,22 +7,22 @@ import (
 
 type SourceServiceMock struct{}
 
-func (r SourceServiceMock) CreateNewSource(user models.Source) error {
+func (r SourceServiceMock) CreateNewSource(user models.Source) (models.Source, error) {
 	ServiceWrapper := error_const.SourceRepositoryError{}
 	RepoWrapper := error_const.SourceServiceError{}
 	switch user.Name {
 	case "Success":
-		return nil
+		return user, nil
 	case "CantConnect":
 		RepoWrapper.Wrap(error_const.FirebaseUnknownError{})
 		ServiceWrapper.Wrap(RepoWrapper)
-		return ServiceWrapper
+		return models.Source{}, ServiceWrapper
 	case "Duplicated":
 		RepoWrapper.Wrap(error_const.FirestoreAlreadyExistsError{DocID: user.UID})
 		ServiceWrapper.Wrap(RepoWrapper)
-		return ServiceWrapper
+		return models.Source{}, ServiceWrapper
 	default:
-		return error_const.TestInvalidTestCaseError{Param: user.Name}
+		return models.Source{}, error_const.TestInvalidTestCaseError{Param: user.Name}
 	}
 }
 
@@ -49,27 +49,27 @@ func (r SourceServiceMock) GetSourceByID(id string) (models.Source, error) {
 	}
 }
 
-func (r SourceServiceMock) UpdateSource(source models.Source) error {
+func (r SourceServiceMock) UpdateSource(source models.Source) (models.Source, error) {
 	id := source.UID
 	ServiceWrapper := error_const.SourceRepositoryError{}
 	RepoWrapper := error_const.SourceServiceError{}
 	switch id {
 	case "0":
-		return nil
+		return source, nil
 	case "1":
 		RepoWrapper.Wrap(error_const.FirebaseUnknownError{})
 		ServiceWrapper.Wrap(RepoWrapper)
-		return ServiceWrapper
+		return models.Source{}, ServiceWrapper
 	case "2":
 		RepoWrapper.Wrap(error_const.FirestoreNotFoundError{DocID: id})
 		ServiceWrapper.Wrap(RepoWrapper)
-		return ServiceWrapper
+		return models.Source{}, ServiceWrapper
 	case "3":
 		RepoWrapper.Wrap(error_const.FirestoreParsingError{DocID: id, StructName: "source"})
 		ServiceWrapper.Wrap(RepoWrapper)
-		return ServiceWrapper
+		return models.Source{}, ServiceWrapper
 	default:
-		return error_const.TestInvalidTestCaseError{Param: id}
+		return models.Source{}, error_const.TestInvalidTestCaseError{Param: id}
 	}
 }
 

--- a/utils/test/mocks/source_service.go
+++ b/utils/test/mocks/source_service.go
@@ -8,7 +8,7 @@ import (
 type SourceServiceMock struct{}
 
 func (r SourceServiceMock) CreateNewSource(user models.Source) error {
-	ServiceWrapper := error_const.SourceServiceError{}
+	ServiceWrapper := error_const.SourceRepositoryError{}
 	RepoWrapper := error_const.SourceServiceError{}
 	switch user.Name {
 	case "Success":
@@ -28,7 +28,7 @@ func (r SourceServiceMock) CreateNewSource(user models.Source) error {
 
 func (r SourceServiceMock) GetSourceByID(id string) (models.Source, error) {
 	ServiceWrapper := error_const.SourceServiceError{}
-	RepoWrapper := error_const.SourceServiceError{}
+	RepoWrapper := error_const.SourceRepositoryError{}
 	switch id {
 	case "0":
 		return TestSource, nil
@@ -52,7 +52,7 @@ func (r SourceServiceMock) GetSourceByID(id string) (models.Source, error) {
 func (r SourceServiceMock) UpdateSource(source models.Source) error {
 	id := source.UID
 	ServiceWrapper := error_const.SourceRepositoryError{}
-	RepoWrapper := error_const.SourceRepositoryError{}
+	RepoWrapper := error_const.SourceServiceError{}
 	switch id {
 	case "0":
 		return nil
@@ -74,8 +74,8 @@ func (r SourceServiceMock) UpdateSource(source models.Source) error {
 }
 
 func (r SourceServiceMock) DeleteSource(id string) error {
-	RepoWrapper := error_const.SourceRepositoryError{}
-	ServiceWrapper := error_const.SourceServiceError{}
+	ServiceWrapper := error_const.SourceRepositoryError{}
+	RepoWrapper := error_const.SourceServiceError{}
 	switch id {
 	case "0":
 		return nil

--- a/utils/test/mocks/source_service.go
+++ b/utils/test/mocks/source_service.go
@@ -72,6 +72,10 @@ func (r SourceServiceMock) UpdateSource(source models.Source) (models.Source, er
 		RepoWrapper.Wrap(error_const.FirestoreParsingError{DocID: id, StructName: "source"})
 		ServiceWrapper.Wrap(RepoWrapper)
 		return models.Source{}, ServiceWrapper
+	case "4":
+		RepoWrapper.Wrap(error_const.SourceCantChangeOwner{SourceID: id, OwnerID: source.OwnerId})
+		ServiceWrapper.Wrap(RepoWrapper)
+		return models.Source{}, ServiceWrapper
 	default:
 		return models.Source{}, error_const.TestInvalidTestCaseError{Param: id}
 	}

--- a/utils/test/mocks/source_service.go
+++ b/utils/test/mocks/source_service.go
@@ -2,6 +2,7 @@ package mocks
 
 import (
 	"github.com/AndresCRamos/midas-app-api/models"
+	util_models "github.com/AndresCRamos/midas-app-api/utils/api/models"
 	error_const "github.com/AndresCRamos/midas-app-api/utils/errors"
 )
 
@@ -27,6 +28,29 @@ func (r SourceServiceMock) CreateNewSource(user models.Source) (models.Source, e
 		return models.Source{}, ServiceWrapper
 	default:
 		return models.Source{}, error_const.TestInvalidTestCaseError{Param: user.Name}
+	}
+}
+
+func (r SourceServiceMock) GetSourcesByUser(userID string, page int) (util_models.PaginatedSearch[models.Source], error) {
+	wrapper := error_const.SourceRepositoryError{}
+	switch userID {
+	case "0":
+		return util_models.PaginatedSearch[models.Source]{
+			CurrentPage: page,
+			TotalData:   1,
+			PageSize:    1,
+			Data: []models.Source{
+				TestSource,
+			},
+		}, nil
+	case "1":
+		wrapper.Wrap(error_const.FirebaseUnknownError{})
+		return util_models.PaginatedSearch[models.Source]{}, wrapper
+	case "2":
+		wrapper.Wrap(error_const.SourceNotEnoughData{})
+		return util_models.PaginatedSearch[models.Source]{}, wrapper
+	default:
+		return util_models.PaginatedSearch[models.Source]{}, error_const.TestInvalidTestCaseError{Param: userID}
 	}
 }
 

--- a/utils/test/mocks/source_service.go
+++ b/utils/test/mocks/source_service.go
@@ -17,6 +17,10 @@ func (r SourceServiceMock) CreateNewSource(user models.Source) (models.Source, e
 		RepoWrapper.Wrap(error_const.FirebaseUnknownError{})
 		ServiceWrapper.Wrap(RepoWrapper)
 		return models.Source{}, ServiceWrapper
+	case "NoOwner":
+		RepoWrapper.Wrap(error_const.SourceOwnerNotFound{SourceID: user.UID, OwnerId: user.OwnerId})
+		ServiceWrapper.Wrap(RepoWrapper)
+		return models.Source{}, ServiceWrapper
 	case "Duplicated":
 		RepoWrapper.Wrap(error_const.FirestoreAlreadyExistsError{DocID: user.UID})
 		ServiceWrapper.Wrap(RepoWrapper)

--- a/utils/test/mocks/source_service.go
+++ b/utils/test/mocks/source_service.go
@@ -30,7 +30,7 @@ func (r SourceServiceMock) CreateNewSource(user models.Source) (models.Source, e
 	}
 }
 
-func (r SourceServiceMock) GetSourceByID(id string) (models.Source, error) {
+func (r SourceServiceMock) GetSourceByID(id string, userId string) (models.Source, error) {
 	ServiceWrapper := error_const.SourceServiceError{}
 	RepoWrapper := error_const.SourceRepositoryError{}
 	switch id {

--- a/utils/test/mocks/source_service.go
+++ b/utils/test/mocks/source_service.go
@@ -1,0 +1,97 @@
+package mocks
+
+import (
+	"github.com/AndresCRamos/midas-app-api/models"
+	error_const "github.com/AndresCRamos/midas-app-api/utils/errors"
+)
+
+type SourceServiceMock struct{}
+
+func (r SourceServiceMock) CreateNewSource(user models.Source) error {
+	ServiceWrapper := error_const.SourceServiceError{}
+	RepoWrapper := error_const.SourceServiceError{}
+	switch user.Name {
+	case "Success":
+		return nil
+	case "CantConnect":
+		RepoWrapper.Wrap(error_const.FirebaseUnknownError{})
+		ServiceWrapper.Wrap(RepoWrapper)
+		return ServiceWrapper
+	case "Duplicated":
+		RepoWrapper.Wrap(error_const.FirestoreAlreadyExistsError{DocID: user.UID})
+		ServiceWrapper.Wrap(RepoWrapper)
+		return ServiceWrapper
+	default:
+		return error_const.TestInvalidTestCaseError{Param: user.Name}
+	}
+}
+
+func (r SourceServiceMock) GetSourceByID(id string) (models.Source, error) {
+	ServiceWrapper := error_const.SourceServiceError{}
+	RepoWrapper := error_const.SourceServiceError{}
+	switch id {
+	case "0":
+		return TestSource, nil
+	case "1":
+		RepoWrapper.Wrap(error_const.FirebaseUnknownError{})
+		ServiceWrapper.Wrap(RepoWrapper)
+		return models.Source{}, ServiceWrapper
+	case "2":
+		RepoWrapper.Wrap(error_const.FirestoreNotFoundError{DocID: id})
+		ServiceWrapper.Wrap(RepoWrapper)
+		return models.Source{}, ServiceWrapper
+	case "3":
+		RepoWrapper.Wrap(error_const.FirestoreParsingError{DocID: id, StructName: "source"})
+		ServiceWrapper.Wrap(RepoWrapper)
+		return models.Source{}, ServiceWrapper
+	default:
+		return models.Source{}, error_const.TestInvalidTestCaseError{Param: id}
+	}
+}
+
+func (r SourceServiceMock) UpdateSource(source models.Source) error {
+	id := source.UID
+	ServiceWrapper := error_const.SourceRepositoryError{}
+	RepoWrapper := error_const.SourceRepositoryError{}
+	switch id {
+	case "0":
+		return nil
+	case "1":
+		RepoWrapper.Wrap(error_const.FirebaseUnknownError{})
+		ServiceWrapper.Wrap(RepoWrapper)
+		return ServiceWrapper
+	case "2":
+		RepoWrapper.Wrap(error_const.FirestoreNotFoundError{DocID: id})
+		ServiceWrapper.Wrap(RepoWrapper)
+		return ServiceWrapper
+	case "3":
+		RepoWrapper.Wrap(error_const.FirestoreParsingError{DocID: id, StructName: "source"})
+		ServiceWrapper.Wrap(RepoWrapper)
+		return ServiceWrapper
+	default:
+		return error_const.TestInvalidTestCaseError{Param: id}
+	}
+}
+
+func (r SourceServiceMock) DeleteSource(id string) error {
+	RepoWrapper := error_const.SourceRepositoryError{}
+	ServiceWrapper := error_const.SourceServiceError{}
+	switch id {
+	case "0":
+		return nil
+	case "1":
+		RepoWrapper.Wrap(error_const.FirebaseUnknownError{})
+		ServiceWrapper.Wrap(RepoWrapper)
+		return ServiceWrapper
+	case "2":
+		RepoWrapper.Wrap(error_const.FirestoreNotFoundError{DocID: id})
+		ServiceWrapper.Wrap(RepoWrapper)
+		return ServiceWrapper
+	case "3":
+		RepoWrapper.Wrap(error_const.FirestoreParsingError{DocID: id, StructName: "source"})
+		ServiceWrapper.Wrap(RepoWrapper)
+		return ServiceWrapper
+	default:
+		return error_const.TestInvalidTestCaseError{Param: id}
+	}
+}

--- a/utils/test/test_init.go
+++ b/utils/test/test_init.go
@@ -97,8 +97,14 @@ func ClearFireStoreTest(client *firestore.Client, operation string, args map[str
 	ctx := context.Background()
 	if operation == "Create" {
 		collectionDelete := args["Collection"].(string)
-		deleteId := args["id"].(string)
-		_, _ = client.Collection(collectionDelete).Doc(deleteId).Delete(ctx)
+		deleteID := args["id"].(string)
+		_, _ = client.Collection(collectionDelete).Doc(deleteID).Delete(ctx)
+	}
+	if operation == "Update" {
+		collectionDelete := args["Collection"].(string)
+		updateID := args["id"].(string)
+		originalData := args["originalData"]
+		_, _ = client.Collection(collectionDelete).Doc(updateID).Set(ctx, originalData)
 	}
 
 }


### PR DESCRIPTION
# Feature/sources endpoint
The URI representing sources (a group of movements that share the same provenance) was created, and has the following capabilities
POST /source Create a new source, which owner is denoted by the access token used
GET /source Get all sources of a user, paginated in groups of 50
GET /source/:id Get a specific source, note that to get the data, the authorization token owner must be the source's owner
PUT /source/:id Update a specific source, note that to update the data, the authorization token owner must be the source's owner
DELETE /source/:id Delete a source, to delete the authorization token owner must be the source's owner

Some of the changes added:
- Moved checkFirebaseErrors to error_utils
- checkFirebaseError now accepts string uid instead of User model
- add typeName parameter to checkFirebaseError to check procedence of an error
- Changed test constants names to better differentiate between tests
- Created struct errors for Token validation
- Created PaginatedSearchModel with Generic
- Add delete operation to ClearFirestoreTest
