### PR TITLE
Get from map use generics

### DIFF
--- a/repository/source_repo_test.go
+++ b/repository/source_repo_test.go
@@ -104,7 +104,7 @@ func TestSourceRepositoryImplementation_CreateNewSource(t *testing.T) {
 				"firestoreClient": firestoreClient,
 			},
 			Args: test_utils.Args{
-				"source": &models.Source{UID: "0", Name: "TestSource", OwnerId: "0"},
+				"source": models.Source{UID: "0", Name: "TestSource", OwnerId: "0"},
 			},
 			WantErr:     false,
 			ExpectedErr: nil,
@@ -116,7 +116,7 @@ func TestSourceRepositoryImplementation_CreateNewSource(t *testing.T) {
 				"firestoreClient": firestoreClientFail,
 			},
 			Args: test_utils.Args{
-				"source": &models.Source{},
+				"source": models.Source{},
 			},
 			WantErr:     true,
 			ExpectedErr: error_utils.FirebaseUnknownError{},
@@ -128,7 +128,7 @@ func TestSourceRepositoryImplementation_CreateNewSource(t *testing.T) {
 				"firestoreClient": firestoreClient,
 			},
 			Args: test_utils.Args{
-				"source": &models.Source{UID: "0", Name: "TestSource", OwnerId: "1"},
+				"source": models.Source{UID: "0", Name: "TestSource", OwnerId: "1"},
 			},
 			WantErr:     true,
 			ExpectedErr: error_utils.SourceOwnerNotFound{SourceID: "0", OwnerId: "1"},
@@ -144,12 +144,12 @@ func TestSourceRepositoryImplementation_CreateNewSource(t *testing.T) {
 			if tt.PreTest != nil {
 				tt.PreTest(t)
 			}
-			testFirestoreClient := test_utils.GetFieldByNameAndType(t, tt.Fields, "firestoreClient", new(firestore.Client))
+			testFirestoreClient := test_utils.GetFieldByNameAndType[*firestore.Client](t, tt.Fields, "firestoreClient")
 			r := &SourceRepositoryImplementation{
-				client: testFirestoreClient.(*firestore.Client),
+				client: testFirestoreClient,
 			}
-			sourceTest := test_utils.GetArgByNameAndType(t, tt.Args, "source", new(models.Source)).(*models.Source)
-			res, err := r.CreateNewSource(*sourceTest)
+			sourceTest := test_utils.GetArgByNameAndType[models.Source](t, tt.Args, "source")
+			res, err := r.CreateNewSource(sourceTest)
 			if !tt.WantErr {
 				assert.NoError(t, err)
 				assert.Equal(t, sourceTest.Name, res.Name)
@@ -240,16 +240,16 @@ func TestSourceRepositoryImplementation_GetSourcesByUser(t *testing.T) {
 				tt.PreTest(t)
 			}
 			r := &SourceRepositoryImplementation{
-				client: test_utils.GetFieldByNameAndType(t, tt.Fields, "firestoreClient", new(firestore.Client)).(*firestore.Client),
+				client: test_utils.GetFieldByNameAndType[*firestore.Client](t, tt.Fields, "firestoreClient"),
 			}
-			userID := test_utils.GetArgByNameAndType(t, tt.Args, "userID", "").(string)
-			page := test_utils.GetArgByNameAndType(t, tt.Args, "page", 0).(int)
+			userID := test_utils.GetArgByNameAndType[string](t, tt.Args, "userID")
+			page := test_utils.GetArgByNameAndType[int](t, tt.Args, "page")
 
 			res, err := r.GetSourcesByUser(userID, page)
 			if !tt.WantErr {
 				assert.NoError(t, err)
 				assert.NotEmpty(t, res)
-				expectedPageSize := test_utils.GetArgByNameAndType(t, tt.Args, "expectedPageSize", 0).(int)
+				expectedPageSize := test_utils.GetArgByNameAndType[int](t, tt.Args, "expectedPageSize")
 				assert.Equal(t, expectedPageSize, res.PageSize)
 			} else {
 				assert.Error(t, err)
@@ -338,10 +338,10 @@ func TestSourceRepositoryImplementation_GetSourceByID(t *testing.T) {
 				tt.PreTest(t)
 			}
 			r := &SourceRepositoryImplementation{
-				client: test_utils.GetFieldByNameAndType(t, tt.Fields, "firestoreClient", new(firestore.Client)).(*firestore.Client),
+				client: test_utils.GetFieldByNameAndType[*firestore.Client](t, tt.Fields, "firestoreClient"),
 			}
-			sourceTestId := test_utils.GetArgByNameAndType(t, tt.Args, "id", "").(string)
-			userID := test_utils.GetArgByNameAndType(t, tt.Args, "userID", "").(string)
+			sourceTestId := test_utils.GetArgByNameAndType[string](t, tt.Args, "id")
+			userID := test_utils.GetArgByNameAndType[string](t, tt.Args, "userID")
 
 			res, err := r.GetSourceByID(sourceTestId, userID)
 			if !tt.WantErr {
@@ -379,7 +379,7 @@ func TestSourceRepositoryImplementation_UpdateSource(t *testing.T) {
 				"firestoreClient": firestoreClient,
 			},
 			Args: test_utils.Args{
-				"source": &models.Source{UID: createdSourceUID, Name: "Update Source", OwnerId: "0"},
+				"source": models.Source{UID: createdSourceUID, Name: "Update Source", OwnerId: "0"},
 			},
 			WantErr:     false,
 			ExpectedErr: nil,
@@ -391,7 +391,7 @@ func TestSourceRepositoryImplementation_UpdateSource(t *testing.T) {
 				"firestoreClient": firestoreClientFail,
 			},
 			Args: test_utils.Args{
-				"source": &models.Source{},
+				"source": models.Source{},
 			},
 			WantErr:     true,
 			ExpectedErr: error_utils.FirebaseUnknownError{},
@@ -403,7 +403,7 @@ func TestSourceRepositoryImplementation_UpdateSource(t *testing.T) {
 				"firestoreClient": firestoreClient,
 			},
 			Args: test_utils.Args{
-				"source": &models.Source{UID: "100", Name: "Not found Source"},
+				"source": models.Source{UID: "100", Name: "Not found Source"},
 			},
 			WantErr:     true,
 			ExpectedErr: error_utils.FirestoreNotFoundError{DocID: originalSource.UID},
@@ -417,12 +417,12 @@ func TestSourceRepositoryImplementation_UpdateSource(t *testing.T) {
 			if tt.PreTest != nil {
 				tt.PreTest(t)
 			}
-			testFirestoreClient := test_utils.GetFieldByNameAndType(t, tt.Fields, "firestoreClient", new(firestore.Client))
+			testFirestoreClient := test_utils.GetFieldByNameAndType[*firestore.Client](t, tt.Fields, "firestoreClient")
 			r := &SourceRepositoryImplementation{
-				client: testFirestoreClient.(*firestore.Client),
+				client: testFirestoreClient,
 			}
-			sourceTest := test_utils.GetArgByNameAndType(t, tt.Args, "source", new(models.Source)).(*models.Source)
-			_, err := r.UpdateSource(*sourceTest)
+			sourceTest := test_utils.GetArgByNameAndType[models.Source](t, tt.Args, "source")
+			_, err := r.UpdateSource(sourceTest)
 			if !tt.WantErr {
 				assert.NoError(t, err)
 			} else {
@@ -510,9 +510,9 @@ func TestSourceRepositoryImplementation_DeleteSource(t *testing.T) {
 				tt.PreTest(t)
 			}
 			r := &SourceRepositoryImplementation{
-				client: test_utils.GetFieldByNameAndType(t, tt.Fields, "firestoreClient", new(firestore.Client)).(*firestore.Client),
+				client: test_utils.GetFieldByNameAndType[*firestore.Client](t, tt.Fields, "firestoreClient"),
 			}
-			sourceTestId := test_utils.GetArgByNameAndType(t, tt.Args, "id", "").(string)
+			sourceTestId := test_utils.GetArgByNameAndType[string](t, tt.Args, "id")
 
 			err := r.DeleteSource(sourceTestId, "0")
 			if !tt.WantErr {

--- a/repository/user_repo_test.go
+++ b/repository/user_repo_test.go
@@ -38,7 +38,7 @@ func TestUserRepositoryImplementation_CreateNewUser(t *testing.T) {
 				"firestoreClient": firestoreClient,
 			},
 			Args: test_utils.Args{
-				"user": &models.User{UID: "0", Alias: "TestUser"},
+				"user": models.User{UID: "0", Alias: "TestUser"},
 			},
 			WantErr:     false,
 			ExpectedErr: nil,
@@ -50,7 +50,7 @@ func TestUserRepositoryImplementation_CreateNewUser(t *testing.T) {
 				"firestoreClient": firestoreClientFail,
 			},
 			Args: test_utils.Args{
-				"user": &models.User{},
+				"user": models.User{},
 			},
 			WantErr:     true,
 			ExpectedErr: error_utils.FirebaseUnknownError{},
@@ -62,7 +62,7 @@ func TestUserRepositoryImplementation_CreateNewUser(t *testing.T) {
 				"firestoreClient": firestoreClient,
 			},
 			Args: test_utils.Args{
-				"user": &dupUser,
+				"user": dupUser,
 			},
 			WantErr:     true,
 			ExpectedErr: error_utils.FirestoreAlreadyExistsError{DocID: dupUser.UID},
@@ -75,13 +75,12 @@ func TestUserRepositoryImplementation_CreateNewUser(t *testing.T) {
 			if tt.PreTest != nil {
 				tt.PreTest(t)
 			}
-			testFirestoreClient := test_utils.GetFieldByNameAndType(t, tt.Fields, "firestoreClient", new(firestore.Client))
+			testFirestoreClient := test_utils.GetFieldByNameAndType[*firestore.Client](t, tt.Fields, "firestoreClient")
 			r := &UserRepositoryImplementation{
-				client: testFirestoreClient.(*firestore.Client),
+				client: testFirestoreClient,
 			}
-			// userTest := tt.Args["user"].(models.User)
-			userTest := test_utils.GetArgByNameAndType(t, tt.Args, "user", new(models.User)).(*models.User)
-			err := r.CreateNewUser(*userTest)
+			userTest := test_utils.GetArgByNameAndType[models.User](t, tt.Args, "user")
+			err := r.CreateNewUser(userTest)
 			if !tt.WantErr {
 				assert.NoError(t, err)
 			} else {
@@ -163,9 +162,9 @@ func TestUserRepositoryImplementation_GetUserByID(t *testing.T) {
 				tt.PreTest(t)
 			}
 			r := &UserRepositoryImplementation{
-				client: test_utils.GetFieldByNameAndType(t, tt.Fields, "firestoreClient", new(firestore.Client)).(*firestore.Client),
+				client: test_utils.GetFieldByNameAndType[*firestore.Client](t, tt.Fields, "firestoreClient"),
 			}
-			userTestId := test_utils.GetArgByNameAndType(t, tt.Args, "id", "").(string)
+			userTestId := test_utils.GetArgByNameAndType[string](t, tt.Args, "id")
 
 			res, err := r.GetUserByID(userTestId)
 			if !tt.WantErr {

--- a/services/source_service_test.go
+++ b/services/source_service_test.go
@@ -25,7 +25,7 @@ func Test_sourceServiceImplementation_CreateNewSource(t *testing.T) {
 			Name:   "Success",
 			Fields: fields,
 			Args: test_utils.Args{
-				"source": &models.Source{Name: "Success"},
+				"source": models.Source{Name: "Success"},
 			},
 			WantErr:     false,
 			ExpectedErr: nil,
@@ -35,7 +35,7 @@ func Test_sourceServiceImplementation_CreateNewSource(t *testing.T) {
 			Name:   "Fail to connect",
 			Fields: fields,
 			Args: test_utils.Args{
-				"source": &models.Source{Name: "CantConnect"},
+				"source": models.Source{Name: "CantConnect"},
 			},
 			WantErr:     true,
 			ExpectedErr: error_utils.FirebaseUnknownError{},
@@ -45,7 +45,7 @@ func Test_sourceServiceImplementation_CreateNewSource(t *testing.T) {
 			Name:   "Duplicated Source",
 			Fields: fields,
 			Args: test_utils.Args{
-				"source": &models.Source{Name: "Duplicated", UID: "0"},
+				"source": models.Source{Name: "Duplicated", UID: "0"},
 			},
 			WantErr:     true,
 			ExpectedErr: error_utils.FirestoreAlreadyExistsError{},
@@ -58,12 +58,12 @@ func Test_sourceServiceImplementation_CreateNewSource(t *testing.T) {
 			if tt.PreTest != nil {
 				tt.PreTest(t)
 			}
-			mockRepo := test_utils.GetFieldByNameAndType(t, tt.Fields, "mockRepo", new(repository.SourceRepository))
+			mockRepo := test_utils.GetFieldByNameAndType[repository.SourceRepository](t, tt.Fields, "mockRepo")
 			s := &sourceServiceImplementation{
-				r: mockRepo.(repository.SourceRepository),
+				r: mockRepo,
 			}
-			sourceTest := test_utils.GetArgByNameAndType(t, tt.Args, "source", new(models.Source)).(*models.Source)
-			_, err := s.CreateNewSource(*sourceTest)
+			sourceTest := test_utils.GetArgByNameAndType[models.Source](t, tt.Args, "source")
+			_, err := s.CreateNewSource(sourceTest)
 			if !tt.WantErr {
 				assert.NoError(t, err)
 			} else {
@@ -129,14 +129,14 @@ func Test_sourceServiceImplementation_GetSourcesByUser(t *testing.T) {
 			if tt.PreTest != nil {
 				tt.PreTest(t)
 			}
-			mockRepo := test_utils.GetFieldByNameAndType(t, tt.Fields, "mockRepo", new(repository.SourceRepository))
+			mockRepo := test_utils.GetFieldByNameAndType[repository.SourceRepository](t, tt.Fields, "mockRepo")
 			s := &sourceServiceImplementation{
-				r: mockRepo.(repository.SourceRepository),
+				r: mockRepo,
 			}
-			userId := test_utils.GetArgByNameAndType(t, tt.Args, "userID", "").(string)
+			userId := test_utils.GetArgByNameAndType[string](t, tt.Args, "userID")
 			got, err := s.GetSourcesByUser(userId, 1)
 			if !tt.WantErr {
-				expected := test_utils.GetArgByNameAndType(t, tt.Args, "expectedData", util_models.PaginatedSearch[models.Source]{})
+				expected := test_utils.GetArgByNameAndType[util_models.PaginatedSearch[models.Source]](t, tt.Args, "expectedData")
 				assert.NoError(t, err)
 				assert.Equal(t, expected, got)
 			} else {
@@ -204,11 +204,11 @@ func Test_sourceServiceImplementation_GetSourceByID(t *testing.T) {
 			if tt.PreTest != nil {
 				tt.PreTest(t)
 			}
-			mockRepo := test_utils.GetFieldByNameAndType(t, tt.Fields, "mockRepo", new(repository.SourceRepository))
+			mockRepo := test_utils.GetFieldByNameAndType[repository.SourceRepository](t, tt.Fields, "mockRepo")
 			s := &sourceServiceImplementation{
-				r: mockRepo.(repository.SourceRepository),
+				r: mockRepo,
 			}
-			id := test_utils.GetArgByNameAndType(t, tt.Args, "id", "").(string)
+			id := test_utils.GetArgByNameAndType[string](t, tt.Args, "id")
 			got, err := s.GetSourceByID(id, "123")
 			if !tt.WantErr {
 				assert.Equal(t, got, mocks.TestSource)
@@ -235,7 +235,7 @@ func Test_sourceServiceImplementation_UpdateSource(t *testing.T) {
 			Name:   "Success",
 			Fields: fields,
 			Args: test_utils.Args{
-				"source": &models.Source{Name: "Success", UID: "0"},
+				"source": models.Source{Name: "Success", UID: "0"},
 			},
 			WantErr:     false,
 			ExpectedErr: nil,
@@ -245,7 +245,7 @@ func Test_sourceServiceImplementation_UpdateSource(t *testing.T) {
 			Name:   "Fail to connect",
 			Fields: fields,
 			Args: test_utils.Args{
-				"source": &models.Source{Name: "Cant update", UID: "1"},
+				"source": models.Source{Name: "Cant update", UID: "1"},
 			},
 			WantErr:     true,
 			ExpectedErr: error_utils.FirebaseUnknownError{},
@@ -255,7 +255,7 @@ func Test_sourceServiceImplementation_UpdateSource(t *testing.T) {
 			Name:   "Cant find",
 			Fields: fields,
 			Args: test_utils.Args{
-				"source": &models.Source{Name: "Cant update", UID: "2"},
+				"source": models.Source{Name: "Cant update", UID: "2"},
 			},
 			WantErr:     true,
 			ExpectedErr: error_utils.FirestoreNotFoundError{},
@@ -268,12 +268,12 @@ func Test_sourceServiceImplementation_UpdateSource(t *testing.T) {
 			if tt.PreTest != nil {
 				tt.PreTest(t)
 			}
-			mockRepo := test_utils.GetFieldByNameAndType(t, tt.Fields, "mockRepo", new(repository.SourceRepository))
+			mockRepo := test_utils.GetFieldByNameAndType[repository.SourceRepository](t, tt.Fields, "mockRepo")
 			s := &sourceServiceImplementation{
-				r: mockRepo.(repository.SourceRepository),
+				r: mockRepo,
 			}
-			testSource := test_utils.GetArgByNameAndType(t, tt.Args, "source", new(models.Source)).(*models.Source)
-			_, err := s.UpdateSource(*testSource)
+			testSource := test_utils.GetArgByNameAndType[models.Source](t, tt.Args, "source")
+			_, err := s.UpdateSource(testSource)
 			if !tt.WantErr {
 				assert.NoError(t, err)
 			} else {
@@ -331,11 +331,11 @@ func Test_sourceServiceImplementation_DeleteSource(t *testing.T) {
 			if tt.PreTest != nil {
 				tt.PreTest(t)
 			}
-			mockRepo := test_utils.GetFieldByNameAndType(t, tt.Fields, "mockRepo", new(repository.SourceRepository))
+			mockRepo := test_utils.GetFieldByNameAndType[repository.SourceRepository](t, tt.Fields, "mockRepo")
 			s := &sourceServiceImplementation{
-				r: mockRepo.(repository.SourceRepository),
+				r: mockRepo,
 			}
-			deleteIDSource := test_utils.GetArgByNameAndType(t, tt.Args, "id", "").(string)
+			deleteIDSource := test_utils.GetArgByNameAndType[string](t, tt.Args, "id")
 			err := s.DeleteSource(deleteIDSource, "123")
 			if !tt.WantErr {
 				assert.NoError(t, err)

--- a/services/user_service_test.go
+++ b/services/user_service_test.go
@@ -24,7 +24,7 @@ func Test_userServiceImplementation_CreateNewUser(t *testing.T) {
 			Name:   "Success",
 			Fields: fields,
 			Args: test_utils.Args{
-				"user": &models.User{Name: "Success"},
+				"user": models.User{Name: "Success"},
 			},
 			WantErr:     false,
 			ExpectedErr: nil,
@@ -34,7 +34,7 @@ func Test_userServiceImplementation_CreateNewUser(t *testing.T) {
 			Name:   "Fail to connect",
 			Fields: fields,
 			Args: test_utils.Args{
-				"user": &models.User{Name: "CantConnect"},
+				"user": models.User{Name: "CantConnect"},
 			},
 			WantErr:     true,
 			ExpectedErr: error_utils.FirebaseUnknownError{},
@@ -44,7 +44,7 @@ func Test_userServiceImplementation_CreateNewUser(t *testing.T) {
 			Name:   "Duplicated User",
 			Fields: fields,
 			Args: test_utils.Args{
-				"user": &models.User{Name: "Duplicated", UID: "0"},
+				"user": models.User{Name: "Duplicated", UID: "0"},
 			},
 			WantErr:     true,
 			ExpectedErr: error_utils.FirestoreAlreadyExistsError{},
@@ -57,12 +57,12 @@ func Test_userServiceImplementation_CreateNewUser(t *testing.T) {
 			if tt.PreTest != nil {
 				tt.PreTest(t)
 			}
-			mockRepo := test_utils.GetFieldByNameAndType(t, tt.Fields, "mockRepo", new(repository.UserRepository))
+			mockRepo := test_utils.GetFieldByNameAndType[repository.UserRepository](t, tt.Fields, "mockRepo")
 			s := &userServiceImplementation{
-				r: mockRepo.(repository.UserRepository),
+				r: mockRepo,
 			}
-			userTest := test_utils.GetArgByNameAndType(t, tt.Args, "user", new(models.User)).(*models.User)
-			err := s.CreateNewUser(*userTest)
+			userTest := test_utils.GetArgByNameAndType[models.User](t, tt.Args, "user")
+			err := s.CreateNewUser(userTest)
 			if !tt.WantErr {
 				assert.NoError(t, err)
 			} else {
@@ -130,11 +130,11 @@ func Test_userServiceImplementation_GetUserByID(t *testing.T) {
 			if tt.PreTest != nil {
 				tt.PreTest(t)
 			}
-			mockRepo := test_utils.GetFieldByNameAndType(t, tt.Fields, "mockRepo", new(repository.UserRepository))
+			mockRepo := test_utils.GetFieldByNameAndType[repository.UserRepository](t, tt.Fields, "mockRepo")
 			s := &userServiceImplementation{
-				r: mockRepo.(repository.UserRepository),
+				r: mockRepo,
 			}
-			id := test_utils.GetArgByNameAndType(t, tt.Args, "id", "").(string)
+			id := test_utils.GetArgByNameAndType[string](t, tt.Args, "id")
 			got, err := s.GetUserByID(id)
 			if !tt.WantErr {
 				assert.Equal(t, got, mocks.TestUser)

--- a/utils/errors/helper.go
+++ b/utils/errors/helper.go
@@ -1,0 +1,37 @@
+package errors
+
+import "fmt"
+
+type ArgNotFoundError struct {
+	Name string
+}
+
+func (ane ArgNotFoundError) Error() string {
+	return fmt.Sprintf("Cant find arg %s", ane.Name)
+}
+
+type ArgTypeAssertionError[T any] struct {
+	Name  string
+	Value T
+}
+
+func (ate ArgTypeAssertionError[t]) Error() string {
+	return fmt.Sprintf("Cant assert %s arg to type %T", ate.Name, ate.Value)
+}
+
+type FieldNotFoundError struct {
+	Name string
+}
+
+func (fne FieldNotFoundError) Error() string {
+	return fmt.Sprintf("Cant find field %s", fne.Name)
+}
+
+type FieldTypeAssertionError[T any] struct {
+	Name  string
+	Value T
+}
+
+func (fte FieldTypeAssertionError[T]) Error() string {
+	return fmt.Sprintf("Cant assert %s field to type %T", fte.Name, fte.Value)
+}

--- a/utils/test/helper.go
+++ b/utils/test/helper.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"errors"
-	"fmt"
 	"testing"
 
 	error_utils "github.com/AndresCRamos/midas-app-api/utils/errors"
@@ -30,10 +29,10 @@ func ShouldGetArgByNameAndType[T any](args Args, name string) (T, error) {
 	value, err := getFromMap[T](args, name)
 	if err != nil {
 		if errors.Is(err, error_utils.TestMapInterfaceNotFoundError{}) {
-			return value, fmt.Errorf("Cant find arg %s", name)
+			return value, error_utils.ArgNotFoundError{Name: name}
 		}
 		if errors.Is(err, error_utils.TestMapInterfaceCantAssertError{}) {
-			return value, fmt.Errorf("Cant assert %s arg to type %T", name, value)
+			return value, error_utils.ArgTypeAssertionError[T]{Name: name, Value: value}
 		}
 	}
 
@@ -53,10 +52,10 @@ func ShouldGetFieldByNameAndType[T any](fields Fields, name string) (T, error) {
 	value, err := getFromMap[T](fields, name)
 	if err != nil {
 		if errors.Is(err, error_utils.TestMapInterfaceNotFoundError{}) {
-			return value, fmt.Errorf("Cant find field %s", name)
+			return value, error_utils.FieldNotFoundError{Name: name}
 		}
 		if errors.Is(err, error_utils.TestMapInterfaceCantAssertError{}) {
-			return value, fmt.Errorf("Cant assert %s field to type %T", name, value)
+			return value, error_utils.FieldTypeAssertionError[T]{Name: name, Value: value}
 		}
 	}
 	return value, nil

--- a/utils/test/helper.go
+++ b/utils/test/helper.go
@@ -3,7 +3,6 @@ package test
 import (
 	"errors"
 	"fmt"
-	"reflect"
 	"testing"
 
 	error_utils "github.com/AndresCRamos/midas-app-api/utils/errors"
@@ -26,69 +25,62 @@ type Args map[string]interface{}
 
 type ExpectedValues map[string]interface{}
 
-func ShouldGetArgByNameAndType(args Args, name string, targetType any) (any, error) {
-	value, err := getFromMap(args, name, targetType)
+func ShouldGetArgByNameAndType[T any](args Args, name string) (T, error) {
+	var value T
+	value, err := getFromMap[T](args, name)
 	if err != nil {
 		if errors.Is(err, error_utils.TestMapInterfaceNotFoundError{}) {
-			return nil, fmt.Errorf("Cant find arg %s", name)
+			return value, fmt.Errorf("Cant find arg %s", name)
 		}
 		if errors.Is(err, error_utils.TestMapInterfaceCantAssertError{}) {
-			return nil, fmt.Errorf("Cant assert %s arg to type %T", name, targetType)
+			return value, fmt.Errorf("Cant assert %s arg to type %T", name, value)
 		}
 	}
+
 	return value, nil
 }
 
-func GetArgByNameAndType(t *testing.T, args Args, name string, targetType any) any {
-	value, err := ShouldGetArgByNameAndType(args, name, targetType)
+func GetArgByNameAndType[T any](t *testing.T, args Args, name string, targetType any) T {
+	value, err := ShouldGetArgByNameAndType[T](args, name)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
 	return value
 }
 
-func ShouldGetFieldByNameAndType(fields Fields, name string, targetType any) (any, error) {
-	value, err := getFromMap(fields, name, targetType)
+func ShouldGetFieldByNameAndType[T any](fields Fields, name string) (T, error) {
+	var value T
+	value, err := getFromMap[T](fields, name)
 	if err != nil {
 		if errors.Is(err, error_utils.TestMapInterfaceNotFoundError{}) {
-			return nil, fmt.Errorf("Cant find field %s", name)
+			return value, fmt.Errorf("Cant find field %s", name)
 		}
 		if errors.Is(err, error_utils.TestMapInterfaceCantAssertError{}) {
-			return nil, fmt.Errorf("Cant assert %s field to type %T", name, targetType)
+			return value, fmt.Errorf("Cant assert %s field to type %T", name, value)
 		}
 	}
 	return value, nil
 }
 
-func GetFieldByNameAndType(t *testing.T, fields Fields, name string, targetType any) any {
-	value, err := ShouldGetFieldByNameAndType(fields, name, targetType)
+func GetFieldByNameAndType[T any](t *testing.T, fields Fields, name string) any {
+	value, err := ShouldGetFieldByNameAndType[T](fields, name)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
 	return value
 }
 
-func getFromMap(sourceMap map[string]interface{}, name string, targetType any) (any, error) {
+func getFromMap[T any](sourceMap map[string]interface{}, name string) (T, error) {
+	var result T
 	source, ok := sourceMap[name]
 	if !ok {
-		return nil, error_utils.TestMapInterfaceNotFoundError{}
+		return result, error_utils.TestMapInterfaceNotFoundError{}
 	}
 
-	sourceVal := reflect.ValueOf(source)
-	targetTypeVal := reflect.TypeOf(targetType)
-
-	// Check if targetType is an interface
-	if targetTypeVal.Kind() == reflect.Ptr && targetTypeVal.Elem().Kind() == reflect.Interface {
-		// If true, check if val map implements the interface
-		if sourceVal.Type().Implements(targetTypeVal.Elem()) {
-			return source, nil
-		}
-	} else {
-		// Check if the types match directly
-		if sourceVal.Type().AssignableTo(targetTypeVal) {
-			return source, nil
-		}
+	result, ok = source.(T)
+	if ok {
+		return result, nil
 	}
 
-	return nil, error_utils.TestMapInterfaceCantAssertError{}
+	return result, error_utils.TestMapInterfaceCantAssertError{}
 }

--- a/utils/test/helper.go
+++ b/utils/test/helper.go
@@ -39,7 +39,7 @@ func ShouldGetArgByNameAndType[T any](args Args, name string) (T, error) {
 	return value, nil
 }
 
-func GetArgByNameAndType[T any](t *testing.T, args Args, name string, targetType any) T {
+func GetArgByNameAndType[T any](t *testing.T, args Args, name string) T {
 	value, err := ShouldGetArgByNameAndType[T](args, name)
 	if err != nil {
 		t.Fatal(err.Error())
@@ -61,7 +61,7 @@ func ShouldGetFieldByNameAndType[T any](fields Fields, name string) (T, error) {
 	return value, nil
 }
 
-func GetFieldByNameAndType[T any](t *testing.T, fields Fields, name string) any {
+func GetFieldByNameAndType[T any](t *testing.T, fields Fields, name string) T {
 	value, err := ShouldGetFieldByNameAndType[T](fields, name)
 	if err != nil {
 		t.Fatal(err.Error())

--- a/utils/test/helper_test.go
+++ b/utils/test/helper_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	error_utils "github.com/AndresCRamos/midas-app-api/utils/errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -23,150 +24,148 @@ func InterfaceTest(t TestInterface) string {
 	return t.FuncTest()
 }
 
+var (
+	testString = "string"
+	testInt    = 1
+	testFloat  = 1.1
+	testBool   = true
+	testStruct = StructTest{testVal: "test"}
+	testSlice  = []int{1, 2, 3}
+	testMap    = map[string]interface{}{"name": "test"}
+	testError  = errors.New("test")
+)
+
 func Test_getFromMap(t *testing.T) {
-	type args struct {
-		sourceMap  map[string]interface{}
-		name       string
-		targetType interface{}
+	testArgs := map[string]interface{}{
+		"string":    testString,
+		"int":       testInt,
+		"float":     testFloat,
+		"bool":      testBool,
+		"struct":    testStruct,
+		"slice":     testSlice,
+		"map":       testMap,
+		"interface": &testStruct,
+		"error":     testError,
 	}
 
-	testArgs := map[string]interface{}{
-		"string": "string",
-		"int":    1,
-		"float":  1.1,
-		"bool":   true,
-		"struct": struct {
-			Name string
-			Age  int
-		}{
-			Name: "test",
-			Age:  1,
-		},
-		"slice": []int{1, 2, 3},
-		"map": map[string]interface{}{
-			"name": "test",
-		},
-		"interface": &StructTest{testVal: "test"},
-		"error":     errors.New("test"),
-	}
-	tests := []struct {
-		name    string
-		args    args
-		want    interface{}
-		wantErr bool
-	}{
-		{
-			name: "type string",
-			args: args{
-				sourceMap:  testArgs,
-				name:       "string",
-				targetType: "",
-			},
-			want: "string",
-		},
-		{
-			name: "type int",
-			args: args{
-				sourceMap:  testArgs,
-				name:       "int",
-				targetType: 0,
-			},
-			want: 1,
-		},
-		{
-			name: "type float",
-			args: args{
-				sourceMap:  testArgs,
-				name:       "float",
-				targetType: 0.0,
-			},
-			want: 1.1,
-		},
-		{
-			name: "type bool",
-			args: args{
-				sourceMap:  testArgs,
-				name:       "bool",
-				targetType: false,
-			},
-			want: true,
-		},
-		{
-			name: "type struct",
-			args: args{
-				sourceMap: testArgs,
-				name:      "struct",
-				targetType: struct {
-					Name string
-					Age  int
-				}{},
-			},
-			want: struct {
-				Name string
-				Age  int
-			}{
-				Name: "test",
-				Age:  1,
-			},
-		},
-		{
-			name: "type slice",
-			args: args{
-				sourceMap:  testArgs,
-				name:       "slice",
-				targetType: []int{},
-			},
-			want: []int{1, 2, 3},
-		},
-		{
-			name: "type map",
-			args: args{
-				sourceMap:  testArgs,
-				name:       "map",
-				targetType: map[string]interface{}{},
-			},
-			want: map[string]interface{}{
-				"name": "test",
-			},
-		},
-		{
-			name: "type interface",
-			args: args{
-				sourceMap:  testArgs,
-				name:       "interface",
-				targetType: new(TestInterface),
-			},
-			want: &StructTest{testVal: "test"},
-		},
-		{
-			name: "type error",
-			args: args{
-				sourceMap:  testArgs,
-				name:       "error",
-				targetType: new(error),
-			},
-			wantErr: false,
-			want:    errors.New("test"),
-		},
-		{
-			name: "error",
-			args: args{
-				sourceMap:  testArgs,
-				name:       "error",
-				targetType: "",
-			},
-			wantErr: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := getFromMap(tt.args.sourceMap, tt.args.name, tt.args.targetType)
-			if tt.wantErr {
-				assert.Error(t, err)
-				return
-			}
-			assert.NoError(t, err)
-			assert.Equal(t, tt.want, got)
+	{
+		// Test for string type
+		t.Run("Type string", func(t *testing.T) {
+			testGetFromMapString(t, testArgs)
+		})
+
+		// Test for int type
+		t.Run("Type int", func(t *testing.T) {
+			testGetFromMapInt(t, testArgs)
+		})
+
+		// Test for float type
+		t.Run("Type float", func(t *testing.T) {
+			testGetFromMapFloat(t, testArgs)
+		})
+
+		// Test for bool type
+		t.Run("Type bool", func(t *testing.T) {
+			testGetFromMapBool(t, testArgs)
+		})
+
+		// Test for struct type
+		t.Run("Type struct", func(t *testing.T) {
+			testGetFromMapStruct(t, testArgs)
+		})
+
+		// Test for slice type
+		t.Run("Type slice", func(t *testing.T) {
+			testGetFromMapSlice(t, testArgs)
+		})
+
+		// Test for map type
+		t.Run("Type map", func(t *testing.T) {
+			testGetFromMapMap(t, testArgs)
+		})
+
+		// Test for interface type
+		t.Run("Type interface", func(t *testing.T) {
+			testGetFromMapInterface(t, testArgs)
+		})
+
+		// Test for error type
+		t.Run("Type error", func(t *testing.T) {
+			testGetFromMapError(t, testArgs)
+		})
+
+		t.Run("Not found", func(t *testing.T) {
+			testGetFromMapNotFound(t, testArgs)
+		})
+
+		t.Run("Bad type", func(t *testing.T) {
+			testGetFromMapBadType(t, testArgs)
 		})
 	}
+}
+
+func testGetFromMapString(t *testing.T, testArgs map[string]interface{}) {
+	got, err := getFromMap[string](testArgs, "string")
+	assert.NoError(t, err)
+	assert.Equal(t, testString, got)
+}
+
+func testGetFromMapInt(t *testing.T, testArgs map[string]interface{}) {
+	got, err := getFromMap[int](testArgs, "int")
+	assert.NoError(t, err)
+	assert.Equal(t, testInt, got)
+}
+
+func testGetFromMapFloat(t *testing.T, testArgs map[string]interface{}) {
+	got, err := getFromMap[float64](testArgs, "float")
+	assert.NoError(t, err)
+	assert.Equal(t, testFloat, got)
+}
+
+func testGetFromMapBool(t *testing.T, testArgs map[string]interface{}) {
+	got, err := getFromMap[bool](testArgs, "bool")
+	assert.NoError(t, err)
+	assert.Equal(t, testBool, got)
+}
+
+func testGetFromMapStruct(t *testing.T, testArgs map[string]interface{}) {
+	got, err := getFromMap[StructTest](testArgs, "struct")
+	assert.NoError(t, err)
+	assert.Equal(t, testStruct, got)
+}
+
+func testGetFromMapSlice(t *testing.T, testArgs map[string]interface{}) {
+	got, err := getFromMap[[]int](testArgs, "slice")
+	assert.NoError(t, err)
+	assert.Equal(t, testSlice, got)
+}
+
+func testGetFromMapMap(t *testing.T, testArgs map[string]interface{}) {
+	got, err := getFromMap[map[string]interface{}](testArgs, "map")
+	assert.NoError(t, err)
+	assert.Equal(t, testMap, got)
+}
+
+func testGetFromMapInterface(t *testing.T, testArgs map[string]interface{}) {
+	got, err := getFromMap[TestInterface](testArgs, "interface")
+	assert.NoError(t, err)
+	assert.Equal(t, &testStruct, got)
+}
+
+func testGetFromMapError(t *testing.T, testArgs map[string]interface{}) {
+	res, err := getFromMap[error](testArgs, "error")
+	assert.Error(t, res)
+	assert.NoError(t, err)
+}
+
+func testGetFromMapNotFound(t *testing.T, testArgs map[string]interface{}) {
+	_, err := getFromMap[error](testArgs, "not_found")
+	assert.Error(t, err)
+	assert.Equal(t, error_utils.TestMapInterfaceNotFoundError{}, err)
+}
+
+func testGetFromMapBadType(t *testing.T, testArgs map[string]interface{}) {
+	_, err := getFromMap[string](testArgs, "int")
+	assert.Error(t, err)
+	assert.Equal(t, error_utils.TestMapInterfaceCantAssertError{}, err)
 }

--- a/utils/test/helper_test.go
+++ b/utils/test/helper_test.go
@@ -169,3 +169,119 @@ func testGetFromMapBadType(t *testing.T, testArgs map[string]interface{}) {
 	assert.Error(t, err)
 	assert.Equal(t, error_utils.TestMapInterfaceCantAssertError{}, err)
 }
+
+func Test_ShouldGetArgByNameAndType(t *testing.T) {
+	sourceMap := map[string]any{"int": 1, "string": "foo"}
+	test := []TestCase{
+		{
+			Name: "Success",
+			Fields: Fields{
+				"map":       sourceMap,
+				"searchKey": "int",
+			},
+			Args: Args{
+				"expected": 1,
+			},
+			WantErr:     false,
+			ExpectedErr: nil,
+			PreTest:     nil,
+		},
+		{
+			Name: "Not Found",
+			Fields: Fields{
+				"map":       sourceMap,
+				"searchKey": "not_found",
+			},
+			Args: Args{
+				"expected": 1,
+			},
+			WantErr:     true,
+			ExpectedErr: error_utils.ArgNotFoundError{},
+			PreTest:     nil,
+		},
+		{
+			Name: "Type Error",
+			Fields: Fields{
+				"map":       sourceMap,
+				"searchKey": "string",
+			},
+			Args: Args{
+				"expected": 1,
+			},
+			WantErr:     true,
+			ExpectedErr: error_utils.ArgTypeAssertionError[any]{},
+			PreTest:     nil,
+		},
+	}
+	for _, tt := range test {
+		t.Run(tt.Name, func(t *testing.T) {
+			searchKey := tt.Fields["searchKey"].(string)
+			got, err := ShouldGetArgByNameAndType[int](sourceMap, searchKey)
+			if !tt.WantErr {
+				assert.Equal(t, tt.Args["expected"], got)
+			} else {
+				assert.Error(t, err)
+				assert.ErrorAs(t, tt.ExpectedErr, &err)
+			}
+
+		})
+	}
+}
+
+func Test_ShouldGetFieldByNameAndType(t *testing.T) {
+	sourceMap := map[string]any{"int": 1, "string": "foo"}
+	test := []TestCase{
+		{
+			Name: "Success",
+			Fields: Fields{
+				"map":       sourceMap,
+				"searchKey": "int",
+			},
+			Args: Args{
+				"expected": 1,
+			},
+			WantErr:     false,
+			ExpectedErr: nil,
+			PreTest:     nil,
+		},
+		{
+			Name: "Not Found",
+			Fields: Fields{
+				"map":       sourceMap,
+				"searchKey": "not_found",
+			},
+			Args: Args{
+				"expected": 1,
+			},
+			WantErr:     true,
+			ExpectedErr: error_utils.FieldNotFoundError{},
+			PreTest:     nil,
+		},
+		{
+			Name: "Type Error",
+			Fields: Fields{
+				"map":       sourceMap,
+				"searchKey": "string",
+			},
+			Args: Args{
+				"expected": 1,
+			},
+			WantErr:     true,
+			ExpectedErr: error_utils.FieldTypeAssertionError[any]{},
+			PreTest:     nil,
+		},
+	}
+	for _, tt := range test {
+		t.Run(tt.Name, func(t *testing.T) {
+			searchKey := tt.Fields["searchKey"].(string)
+			got, err := ShouldGetFieldByNameAndType[int](sourceMap, searchKey)
+			if !tt.WantErr {
+				assert.Equal(t, tt.Args["expected"], got)
+			} else {
+				assert.Error(t, err)
+				assert.ErrorAs(t, tt.ExpectedErr, &err)
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
# Get from map use generics
Changed following test helper function to use Golang generics instead of reflect pkg or type assertion
- GetFieldByNameAndType
- ShouldGetFieldByNameAndType
- GetArgByNameAndType
- ShouldGetArgByNameAndType
- getSourceTestBody

Other changes include:
- Create error structs for getFromMap function
- Create error structs for ShouldGetField/ArgByNameAndType
- Updated all test to comply with the new helper functions
