### PR TITLE
Feature/create test request

### DIFF
--- a/handlers/source_handler_test.go
+++ b/handlers/source_handler_test.go
@@ -220,7 +220,7 @@ func Test_sourceHandler_GetSourcesByUser(t *testing.T) {
 			userID := test_utils.GetArgByNameAndType[string](t, tt.Args, "userID")
 
 			testRequest := test.TestRequest{
-				Method:      "GET",
+				Method:      http.MethodGet,
 				BasePath:    "/",
 				Handler:     h.GetSourcesByUser,
 				Middlewares: []gin.HandlerFunc{testMiddleware(userID)},
@@ -320,7 +320,7 @@ func Test_sourceHandler_GetSourceByID(t *testing.T) {
 			sourceID := test_utils.GetArgByNameAndType[string](t, tt.Args, "sourceID")
 
 			testRequest := test.TestRequest{
-				Method:      "GET",
+				Method:      http.MethodGet,
 				BasePath:    "/:id",
 				RequestPath: "/" + sourceID,
 				Handler:     h.GetSourceByID,

--- a/handlers/user_handler_test.go
+++ b/handlers/user_handler_test.go
@@ -3,9 +3,7 @@ package handlers
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"net/http"
-	"net/http/httptest"
 	"slices"
 	"strings"
 	"testing"
@@ -15,7 +13,6 @@ import (
 	error_utils "github.com/AndresCRamos/midas-app-api/utils/errors"
 	test_utils "github.com/AndresCRamos/midas-app-api/utils/test"
 	"github.com/AndresCRamos/midas-app-api/utils/test/mocks"
-	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -198,11 +195,7 @@ func Test_userHandler_GetUserByID(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		gin.SetMode(gin.ReleaseMode)
-		testRouter := gin.Default()
-		w := httptest.NewRecorder()
 		t.Run(tt.Name, func(t *testing.T) {
-			var body []byte
 			if tt.PreTest != nil {
 				tt.PreTest(t)
 			}
@@ -212,11 +205,16 @@ func Test_userHandler_GetUserByID(t *testing.T) {
 			}
 
 			userID := test_utils.GetArgByNameAndType[string](t, tt.Args, "userID")
-			url := fmt.Sprintf("/%s", userID)
 
-			testRouter.GET("/:id", h.GetUserByID)
-			req, _ := http.NewRequest("GET", url, bytes.NewBuffer(body))
-			testRouter.ServeHTTP(w, req)
+			testRequest := test_utils.TestRequest{
+				Method:      http.MethodGet,
+				BasePath:    "/:id",
+				RequestPath: "/" + userID,
+				Handler:     h.GetUserByID,
+			}
+
+			w := testRequest.ServeRequest(t)
+
 			expectedCode := test_utils.GetArgByNameAndType[int](t, tt.Args, "expectedCode")
 			assert.Equal(t, expectedCode, w.Code)
 			if !tt.WantErr {

--- a/utils/test/request.go
+++ b/utils/test/request.go
@@ -1,0 +1,68 @@
+package test
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/AndresCRamos/midas-app-api/utils/validations"
+	"github.com/gin-gonic/gin"
+)
+
+type TestRequest struct {
+	Method      string
+	BasePath    string
+	RequestPath string
+	Handler     gin.HandlerFunc
+	Middlewares []gin.HandlerFunc
+	Body        *bytes.Buffer
+	Headers     map[string]string
+	QueryParams map[string]string
+}
+
+func (te TestRequest) ServeRequest(t *testing.T) *httptest.ResponseRecorder {
+
+	if te.BasePath == "" {
+		t.Fatal("Base path must not be empty")
+	}
+
+	gin.SetMode(gin.ReleaseMode)
+	testRouter := gin.New()
+	err := validations.AddCustomValidations()
+	if err != nil {
+		t.Fatalf("Cant add custom validations to gin.Engine:\n%v", err)
+	}
+
+	if te.Middlewares != nil {
+		testRouter.Use(te.Middlewares...)
+	}
+
+	testRouter.Handle(te.Method, te.BasePath, te.Handler)
+
+	if te.RequestPath == "" {
+		te.RequestPath = te.BasePath
+	}
+
+	req, err := http.NewRequest(te.Method, te.RequestPath, te.Body)
+	if err != nil {
+		t.Fatalf("An error has ocurred creating the request:\n%v", err)
+	}
+
+	for headerKey, headerVal := range te.Headers {
+		req.Header.Set(headerKey, headerVal)
+	}
+
+	if te.QueryParams != nil {
+		q := req.URL.Query()
+		for queryParamKey, queryParamVal := range te.QueryParams {
+			q.Add(queryParamKey, queryParamVal)
+		}
+		req.URL.RawQuery = q.Encode()
+	}
+
+	w := httptest.NewRecorder()
+	testRouter.ServeHTTP(w, req)
+
+	return w
+}

--- a/utils/test/request.go
+++ b/utils/test/request.go
@@ -44,6 +44,10 @@ func (te TestRequest) ServeRequest(t *testing.T) *httptest.ResponseRecorder {
 		te.RequestPath = te.BasePath
 	}
 
+	if te.Body == nil {
+		te.Body = bytes.NewBuffer([]byte{})
+	}
+
 	req, err := http.NewRequest(te.Method, te.RequestPath, te.Body)
 	if err != nil {
 		t.Fatalf("An error has ocurred creating the request:\n%v", err)


### PR DESCRIPTION
# Create TestRequest struct helper

Created a new struct called testRequest to facilitate the testing of gin handlers, the structs has the fields:

- Method(string): HTTP method to be used
- BasePath(string): The route to be handled by the Gin Handler
- RequestPath(string): The route to be used in the request
- Handler(gin.HandlerFunc): The gin Handler that will manage the request
- Middlewares([]gin.HandlerFunc): A list of middlewares to add to the gin engine
- Body(*bytes.Buffer): The body of the request
- Headers(map[string]string): The headers of the request
- QueryParams(map[string]string): The query parameters for the request

The testRequest struct has a function called ServeRequest, 

`func (te TestRequest) ServeRequest(t *testing.T) *httptest.ResponseRecorder`

This function creates a request and returns a *httptest.ResponseRecorder with the response to the request