### PR TITLE
Fix/users endpoint token access

### DIFF
--- a/handlers/source_handler_test.go
+++ b/handlers/source_handler_test.go
@@ -15,6 +15,7 @@ import (
 	error_utils "github.com/AndresCRamos/midas-app-api/utils/errors"
 	"github.com/AndresCRamos/midas-app-api/utils/test"
 	test_utils "github.com/AndresCRamos/midas-app-api/utils/test"
+	test_middleware "github.com/AndresCRamos/midas-app-api/utils/test/middleware"
 	"github.com/AndresCRamos/midas-app-api/utils/test/mocks"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
@@ -104,7 +105,7 @@ func Test_sourceHandler_CreateNewSource(t *testing.T) {
 				Method:      http.MethodPost,
 				BasePath:    "/",
 				Handler:     h.CreateNewSource,
-				Middlewares: []gin.HandlerFunc{testMiddleware("123")},
+				Middlewares: []gin.HandlerFunc{test_middleware.TestMiddleware("123")},
 				Body:        bytes.NewBuffer(body),
 			}
 
@@ -223,7 +224,7 @@ func Test_sourceHandler_GetSourcesByUser(t *testing.T) {
 				Method:      http.MethodGet,
 				BasePath:    "/",
 				Handler:     h.GetSourcesByUser,
-				Middlewares: []gin.HandlerFunc{testMiddleware(userID)},
+				Middlewares: []gin.HandlerFunc{test_middleware.TestMiddleware(userID)},
 				QueryParams: map[string]string{},
 			}
 			page, err := test_utils.ShouldGetArgByNameAndType[string](tt.Args, "page")
@@ -324,7 +325,7 @@ func Test_sourceHandler_GetSourceByID(t *testing.T) {
 				BasePath:    "/:id",
 				RequestPath: "/" + sourceID,
 				Handler:     h.GetSourceByID,
-				Middlewares: []gin.HandlerFunc{testMiddleware("123")},
+				Middlewares: []gin.HandlerFunc{test_middleware.TestMiddleware("123")},
 			}
 
 			w := testRequest.ServeRequest(t)
@@ -414,7 +415,7 @@ func Test_sourceHandler_UpdateSource(t *testing.T) {
 				Method:      http.MethodPut,
 				BasePath:    "/:id",
 				RequestPath: "/" + mapNameID[tt.Name],
-				Middlewares: []gin.HandlerFunc{testMiddleware("123")},
+				Middlewares: []gin.HandlerFunc{test_middleware.TestMiddleware("123")},
 				Handler:     h.UpdateSource,
 				Body:        bytes.NewBuffer(getSourceTestBody[models.SourceUpdate](t, tt)),
 			}
@@ -529,7 +530,7 @@ func Test_sourceHandler_DeleteSource(t *testing.T) {
 				BasePath:    "/:id",
 				RequestPath: "/" + sourceID,
 				Handler:     h.DeleteSource,
-				Middlewares: []gin.HandlerFunc{testMiddleware("123")},
+				Middlewares: []gin.HandlerFunc{test_middleware.TestMiddleware("123")},
 			}
 
 			w := testRequest.ServeRequest(t)
@@ -562,11 +563,5 @@ func getSourceTestBody[T any](test *testing.T, testCase test_utils.TestCase) []b
 		bodyStruct := test_utils.GetArgByNameAndType[T](test, testCase.Args, "source")
 		body, _ := json.Marshal(bodyStruct)
 		return body
-	}
-}
-
-func testMiddleware(id string) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		c.Set("user", id)
 	}
 }

--- a/handlers/user_handler.go
+++ b/handlers/user_handler.go
@@ -20,13 +20,19 @@ func NewUserHandler(s services.UserService) *userHandler {
 }
 
 func (h *userHandler) GetUserByID(c *gin.Context) {
-	id := c.Param("id")
+	userID, exists := c.Get("user")
+	if !exists {
+		c.AbortWithStatusJSON(error_utils.CantGetUser{}.GetAPIError())
+		return
+	}
 
-	user, err := h.s.GetUserByID(id)
-	user.UID = id
+	userIDStr := userID.(string)
+
+	user, err := h.s.GetUserByID(userIDStr)
+	user.UID = userIDStr
 
 	if err != nil {
-		apiErr := error_utils.CheckServiceErrors(id, err, "user")
+		apiErr := error_utils.CheckServiceErrors(userIDStr, err, "user")
 		c.AbortWithStatusJSON(apiErr.GetAPIError())
 		return
 	}

--- a/handlers/user_handler_test.go
+++ b/handlers/user_handler_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/AndresCRamos/midas-app-api/services"
 	error_utils "github.com/AndresCRamos/midas-app-api/utils/errors"
 	test_utils "github.com/AndresCRamos/midas-app-api/utils/test"
+	test_middleware "github.com/AndresCRamos/midas-app-api/utils/test/middleware"
 	"github.com/AndresCRamos/midas-app-api/utils/test/mocks"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
@@ -103,7 +104,7 @@ func Test_userHandler_CreateNewUser(t *testing.T) {
 				BasePath:    "/",
 				Handler:     h.CreateNewUser,
 				Body:        bytes.NewBuffer(getUserTestBody(t, tt)),
-				Middlewares: []gin.HandlerFunc{testMiddleware("0")},
+				Middlewares: []gin.HandlerFunc{test_middleware.TestMiddleware("0")},
 			}
 
 			w := testRequest.ServeRequest(t)
@@ -201,7 +202,7 @@ func Test_userHandler_GetUserByID(t *testing.T) {
 				BasePath:    "/:id",
 				RequestPath: "/" + userID,
 				Handler:     h.GetUserByID,
-				Middlewares: []gin.HandlerFunc{testMiddleware(userID)},
+				Middlewares: []gin.HandlerFunc{test_middleware.TestMiddleware(userID)},
 			}
 
 			w := testRequest.ServeRequest(t)

--- a/handlers/user_handler_test.go
+++ b/handlers/user_handler_test.go
@@ -63,18 +63,6 @@ func Test_userHandler_CreateNewUser(t *testing.T) {
 			PreTest:     nil,
 		},
 		{
-			Name:   "No UID",
-			Fields: fields,
-			Args: test_utils.Args{
-				"user":              models.User{Name: "Bad request"},
-				"expectedCode":      http.StatusBadRequest,
-				"expectedErrDetail": []string{"field uid is required"},
-			},
-			WantErr:     true,
-			ExpectedErr: error_utils.APIInvalidRequestBody{},
-			PreTest:     nil,
-		},
-		{
 			Name:   "No Name nor alias",
 			Fields: fields,
 			Args: test_utils.Args{

--- a/handlers/user_handler_test.go
+++ b/handlers/user_handler_test.go
@@ -201,6 +201,7 @@ func Test_userHandler_GetUserByID(t *testing.T) {
 				BasePath:    "/:id",
 				RequestPath: "/" + userID,
 				Handler:     h.GetUserByID,
+				Middlewares: []gin.HandlerFunc{testMiddleware(userID)},
 			}
 
 			w := testRequest.ServeRequest(t)

--- a/handlers/user_handler_test.go
+++ b/handlers/user_handler_test.go
@@ -13,6 +13,7 @@ import (
 	error_utils "github.com/AndresCRamos/midas-app-api/utils/errors"
 	test_utils "github.com/AndresCRamos/midas-app-api/utils/test"
 	"github.com/AndresCRamos/midas-app-api/utils/test/mocks"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -110,10 +111,11 @@ func Test_userHandler_CreateNewUser(t *testing.T) {
 			}
 
 			testRequest := test_utils.TestRequest{
-				Method:   http.MethodPost,
-				BasePath: "/",
-				Handler:  h.CreateNewUser,
-				Body:     bytes.NewBuffer(getUserTestBody(t, tt)),
+				Method:      http.MethodPost,
+				BasePath:    "/",
+				Handler:     h.CreateNewUser,
+				Body:        bytes.NewBuffer(getUserTestBody(t, tt)),
+				Middlewares: []gin.HandlerFunc{testMiddleware("0")},
 			}
 
 			w := testRequest.ServeRequest(t)

--- a/models/users.go
+++ b/models/users.go
@@ -1,8 +1,22 @@
 package models
 
 type User struct {
-	UID      string `firestore:"uid" json:"uid" binding:"required"`
+	UID      string `firestore:"uid" json:"uid"`
+	Alias    string `firestore:"alias" json:"alias"`
+	Name     string `firestore:"name" json:"name"`
+	LastName string `firestore:"last_name" json:"last_name"`
+}
+
+type UserCreate struct {
 	Alias    string `firestore:"alias" json:"alias" binding:"required_without=Name"`
 	Name     string `firestore:"name" json:"name" binding:"required_without=Alias"`
 	LastName string `firestore:"last_name" json:"last_name" binding:"depends_on=Name"`
+}
+
+func (uc *UserCreate) ParseUser() User {
+	return User{
+		Alias:    uc.Alias,
+		Name:     uc.Name,
+		LastName: uc.LastName,
+	}
 }

--- a/routes/user_routes.go
+++ b/routes/user_routes.go
@@ -21,7 +21,6 @@ func addUserRoutes(server *server.Server) {
 	userGroup.Use(middleware.VerifyToken(server.FirebaseAuthClient))
 	{
 		userGroup.POST("/", handler.CreateNewUser)
-		userGroup.GET("/:id", handler.GetUserByID)
+		userGroup.GET("/", handler.GetUserByID)
 	}
-
 }

--- a/utils/test/middleware/middleware.go
+++ b/utils/test/middleware/middleware.go
@@ -1,0 +1,9 @@
+package middleware
+
+import "github.com/gin-gonic/gin"
+
+func TestMiddleware(id string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Set("user", id)
+	}
+}


### PR DESCRIPTION
# User endpoint access using token

Add the Verify Token middleware to user endpoints to get the user ID from token instead of body or URL parameters