### PR TITLE
Feature/movements repository

### DIFF
--- a/models/movement.go
+++ b/models/movement.go
@@ -18,9 +18,9 @@ type Movement struct {
 }
 
 func (m *Movement) NewCreationAtDate() {
-	m.CreatedAt = time.Now()
+	m.CreatedAt = time.Now().UTC()
 }
 
 func (m *Movement) NewUpdatedAtDate() {
-	m.UpdatedAt = time.Now()
+	m.UpdatedAt = time.Now().UTC()
 }

--- a/models/movement.go
+++ b/models/movement.go
@@ -5,16 +5,16 @@ import (
 )
 
 type Movement struct {
-	UID          string    `firebase:"uid"`
-	OwnerId      string    `firebase:"owner"`
-	SourceID     string    `firebase:"source"`
-	Name         string    `firebase:"name"`
-	Description  string    `firebase:"description"`
-	Amount       int64     `firebase:"amount"`
-	MovementDate time.Time `firebase:"movement_date"`
-	Tags         []string  `firebase:"tags"`
-	CreatedAt    time.Time `firebase:"created_at"`
-	UpdatedAt    time.Time `firebase:"updated_at"`
+	UID          string    `firestore:"uid"`
+	OwnerId      string    `firestore:"owner"`
+	SourceID     string    `firestore:"source"`
+	Name         string    `firestore:"name"`
+	Description  string    `firestore:"description"`
+	Amount       int64     `firestore:"amount"`
+	MovementDate time.Time `firestore:"movement_date"`
+	Tags         []string  `firestore:"tags"`
+	CreatedAt    time.Time `firestore:"created_at"`
+	UpdatedAt    time.Time `firestore:"updated_at"`
 }
 
 func (m *Movement) NewCreationAtDate() {

--- a/models/movement.go
+++ b/models/movement.go
@@ -5,13 +5,21 @@ import (
 )
 
 type Movement struct {
-	UID          string
-	OwnerId      string
-	Name         string
-	Description  string
-	Amount       int64
-	MovementDate time.Time
-	Tags         []string
-	CreatedAt    time.Time
-	UpdatedAt    time.Time
+	UID          string    `firebase:"uid"`
+	OwnerId      string    `firebase:"owner"`
+	Name         string    `firebase:"name"`
+	Description  string    `firebase:"description"`
+	Amount       int64     `firebase:"amount"`
+	MovementDate time.Time `firebase:"movement_date"`
+	Tags         []string  `firebase:"tags"`
+	CreatedAt    time.Time `firebase:"created_at"`
+	UpdatedAt    time.Time `firebase:"updated_at"`
+}
+
+func (m *Movement) NewCreationAtDate() {
+	m.CreatedAt = time.Now()
+}
+
+func (m *Movement) NewUpdatedAtDate() {
+	m.UpdatedAt = time.Now()
 }

--- a/models/movement.go
+++ b/models/movement.go
@@ -7,6 +7,7 @@ import (
 type Movement struct {
 	UID          string    `firebase:"uid"`
 	OwnerId      string    `firebase:"owner"`
+	SourceID     string    `firebase:"source"`
 	Name         string    `firebase:"name"`
 	Description  string    `firebase:"description"`
 	Amount       int64     `firebase:"amount"`

--- a/repository/movement_repo.go
+++ b/repository/movement_repo.go
@@ -135,11 +135,66 @@ func (r *movementRepositoryImplementation) GetMovementsByUserAndDate(userID stri
 }
 
 func getMovementDocSnapByID(id string, client *firestore.Client) (*firestore.DocumentSnapshot, error) {
-
 	movementDocSnap, err := client.Collection("movements").Doc(id).Get(context.Background())
-
 	if err != nil {
 		return nil, err
 	}
 	return movementDocSnap, nil
+}
+
+func movementToStruct(m models.Movement) (map[string]interface{}, bool) {
+	var changed bool
+	fields := make(map[string]interface{})
+
+	if m.UID != "" {
+		changed = true
+		fields["uid"] = m.UID
+	}
+
+	if m.OwnerId != "" {
+		changed = true
+		fields["owner"] = m.OwnerId
+	}
+
+	if m.SourceID != "" {
+		changed = true
+		fields["source"] = m.SourceID
+	}
+
+	if m.Name != "" {
+		changed = true
+		fields["name"] = m.Name
+	}
+
+	if m.Description != "" {
+		changed = true
+		fields["description"] = m.Description
+	}
+
+	if m.Amount != 0 {
+		changed = true
+		fields["amount"] = m.Amount
+	}
+
+	if !m.MovementDate.IsZero() {
+		changed = true
+		fields["movement_date"] = m.MovementDate
+	}
+
+	if m.Tags != nil && len(m.Tags) != 0 {
+		changed = true
+		fields["tags"] = m.Tags
+	}
+
+	if !m.CreatedAt.IsZero() {
+		changed = true
+		fields["created_at"] = m.CreatedAt
+	}
+
+	if !m.UpdatedAt.IsZero() {
+		changed = true
+		fields["updated_at"] = m.UpdatedAt
+	}
+
+	return fields, changed
 }

--- a/repository/movement_repo.go
+++ b/repository/movement_repo.go
@@ -90,7 +90,7 @@ func (r *movementRepositoryImplementation) GetMovementByID(id string, userID str
 
 func getMovementDocSnapByID(id string, client *firestore.Client) (*firestore.DocumentSnapshot, error) {
 
-	movementDocSnap, err := client.Collection("sources").Doc(id).Get(context.Background())
+	movementDocSnap, err := client.Collection("movements").Doc(id).Get(context.Background())
 
 	if err != nil {
 		return nil, err

--- a/repository/movement_repo.go
+++ b/repository/movement_repo.go
@@ -1,8 +1,12 @@
 package repository
 
 import (
+	"context"
+
 	"cloud.google.com/go/firestore"
 	"github.com/AndresCRamos/midas-app-api/models"
+	error_utils "github.com/AndresCRamos/midas-app-api/utils/errors"
+	firebase_utils "github.com/AndresCRamos/midas-app-api/utils/firebase"
 )
 
 type MovementRepository interface {
@@ -17,6 +21,43 @@ func NewMovementRepository(client *firestore.Client) *movementRepositoryImplemen
 	return &movementRepositoryImplementation{
 		client: client,
 	}
+}
+
+func (r *movementRepositoryImplementation) CreateNewMovement(movement models.Movement) (models.Movement, error) {
+	userExists, err := firebase_utils.CheckDocumentExists(r.client.Collection("users"), movement.OwnerId)
+	if err != nil {
+		return models.Movement{}, error_utils.CheckFirebaseError(err, movement.SourceID, &error_utils.MovementRepositoryError{})
+	}
+	if !userExists {
+		repoErr := error_utils.MovementRepositoryError{}
+		repoErr.Wrap(error_utils.MovementOwnerNotFound{MovementID: movement.UID, OwnerId: movement.OwnerId})
+		return models.Movement{}, repoErr
+	}
+
+	sourceExists, err := firebase_utils.CheckDocumentExists(r.client.Collection("sources"), movement.SourceID)
+	if err != nil {
+		return models.Movement{}, error_utils.CheckFirebaseError(err, movement.SourceID, &error_utils.MovementRepositoryError{})
+	}
+	if !sourceExists {
+		repoErr := error_utils.MovementRepositoryError{}
+		repoErr.Wrap(error_utils.MovementSourceNotFound{MovementID: movement.UID, SourceID: movement.SourceID})
+		return models.Movement{}, repoErr
+	}
+
+	movementCollection := r.client.Collection("movements")
+
+	movement.NewCreationAtDate()
+	movement.NewUpdatedAtDate()
+
+	docRef := movementCollection.NewDoc()
+	movement.UID = docRef.ID
+
+	_, err = docRef.Set(context.Background(), movement)
+	if err != nil {
+		wrapErr := error_utils.MovementRepositoryError{}
+		return models.Movement{}, error_utils.CheckFirebaseError(err, movement.UID, &wrapErr)
+	}
+	return movement, nil
 }
 
 func (r *movementRepositoryImplementation) GetMovementByID(id string) (models.Movement, error) {

--- a/repository/movement_repo.go
+++ b/repository/movement_repo.go
@@ -90,7 +90,7 @@ func (r *movementRepositoryImplementation) GetMovementByID(id string, userID str
 	return movement, nil
 }
 func (r *movementRepositoryImplementation) GetMovementsByUserAndDate(userID string, page int, from_date time.Time, to_date time.Time) (util_models.PaginatedSearch[models.Movement], error) {
-	movementCollection := r.client.Collection("movement")
+	movementCollection := r.client.Collection("movements")
 	totalQuery := movementCollection.Where("owner", "==", userID).Where("movement_date", ">=", from_date).Where("movement_date", "<=", to_date).OrderBy("movement_date", firestore.Desc)
 	iterSource := totalQuery.Offset((page - 1) * pageSize).Limit(pageSize).Documents(context.Background())
 

--- a/repository/movement_repo.go
+++ b/repository/movement_repo.go
@@ -10,7 +10,8 @@ import (
 )
 
 type MovementRepository interface {
-	GetMovementByID(id string) (models.Movement, error)
+	CreateNewMovement(movement models.Movement) (models.Movement, error)
+	GetMovementByID(id string, userID string) (models.Movement, error)
 }
 
 type movementRepositoryImplementation struct {
@@ -60,6 +61,6 @@ func (r *movementRepositoryImplementation) CreateNewMovement(movement models.Mov
 	return movement, nil
 }
 
-func (r *movementRepositoryImplementation) GetMovementByID(id string) (models.Movement, error) {
+func (r *movementRepositoryImplementation) GetMovementByID(id string, userID string) (models.Movement, error) {
 	return models.Movement{}, nil
 }

--- a/repository/movement_repo.go
+++ b/repository/movement_repo.go
@@ -69,6 +69,7 @@ func (r *movementRepositoryImplementation) GetMovementByID(id string, userID str
 	}
 
 	var movement models.Movement
+
 	if err = movementDocSnap.DataTo(movement); err != nil {
 		wrapErr := error_utils.SourceRepositoryError{}
 		logged_err := error_utils.FirestoreParsingError{DocID: id, StructName: "movement"}
@@ -77,12 +78,10 @@ func (r *movementRepositoryImplementation) GetMovementByID(id string, userID str
 	}
 
 	if userID != movement.OwnerId {
-		return models.Movement{}, error_utils.SourceRepositoryError{
-			Err: error_utils.MovementDifferentOwner{
-				MovementID: id,
-				OwnerID:    userID,
-			},
-		}
+		wrapErr := error_utils.SourceRepositoryError{}
+		logged_err := error_utils.MovementDifferentOwner{MovementID: id, OwnerID: userID}
+		wrapErr.Wrap(logged_err)
+		return models.Movement{}, wrapErr
 	}
 
 	return movement, nil

--- a/repository/movement_repo.go
+++ b/repository/movement_repo.go
@@ -71,7 +71,7 @@ func (r *movementRepositoryImplementation) GetMovementByID(id string, userID str
 	var movement models.Movement
 	if err = movementDocSnap.DataTo(movement); err != nil {
 		wrapErr := error_utils.SourceRepositoryError{}
-		logged_err := error_utils.FirestoreParsingError{DocID: movement.UID, StructName: "movement"}
+		logged_err := error_utils.FirestoreParsingError{DocID: id, StructName: "movement"}
 		wrapErr.Wrap(logged_err)
 		return models.Movement{}, wrapErr
 	}

--- a/repository/movement_repo.go
+++ b/repository/movement_repo.go
@@ -15,6 +15,7 @@ import (
 type MovementRepository interface {
 	CreateNewMovement(movement models.Movement) (models.Movement, error)
 	GetMovementByID(id string, userID string) (models.Movement, error)
+	GetMovementsByUserAndDate(userID string, page int, from_date time.Time, to_date time.Time) (util_models.PaginatedSearch[models.Movement], error)
 }
 
 type movementRepositoryImplementation struct {
@@ -89,6 +90,7 @@ func (r *movementRepositoryImplementation) GetMovementByID(id string, userID str
 
 	return movement, nil
 }
+
 func (r *movementRepositoryImplementation) GetMovementsByUserAndDate(userID string, page int, from_date time.Time, to_date time.Time) (util_models.PaginatedSearch[models.Movement], error) {
 	movementCollection := r.client.Collection("movements")
 	totalQuery := movementCollection.Where("owner", "==", userID).Where("movement_date", ">=", from_date).Where("movement_date", "<=", to_date).OrderBy("movement_date", firestore.Desc)

--- a/repository/movement_repo.go
+++ b/repository/movement_repo.go
@@ -70,7 +70,7 @@ func (r *movementRepositoryImplementation) GetMovementByID(id string, userID str
 
 	var movement models.Movement
 
-	if err = movementDocSnap.DataTo(movement); err != nil {
+	if err = movementDocSnap.DataTo(&movement); err != nil {
 		wrapErr := error_utils.SourceRepositoryError{}
 		logged_err := error_utils.FirestoreParsingError{DocID: id, StructName: "movement"}
 		wrapErr.Wrap(logged_err)

--- a/repository/movement_repo_test.go
+++ b/repository/movement_repo_test.go
@@ -371,6 +371,18 @@ func Test_movementRepositoryImplementation_UpdateMovement(t *testing.T) {
 			ExpectedErr: error_utils.FirestoreNotFoundError{DocID: "100"},
 			PreTest:     nil,
 		},
+		{
+			Name: "Different owner",
+			Fields: test_utils.Fields{
+				"firestoreClient": firestoreClient,
+			},
+			Args: test_utils.Args{
+				"movement": models.Movement{UID: createdMovement.UID, Name: "Not found Movement", OwnerId: "1"},
+			},
+			WantErr:     true,
+			ExpectedErr: error_utils.MovementDifferentOwner{MovementID: createdMovement.UID, OwnerID: "1"},
+			PreTest:     nil,
+		},
 	}
 
 	for _, tt := range tests {

--- a/repository/movement_repo_test.go
+++ b/repository/movement_repo_test.go
@@ -290,12 +290,12 @@ func Test_movementRepositoryImplementation_GetMovementsByUserAndDate(t *testing.
 				assert.NotEmpty(t, res)
 				expectedPageSize := test_utils.GetArgByNameAndType[int](t, tt.Args, "expectedPageSize")
 				assert.Equal(t, expectedPageSize, res.PageSize)
+				for _, data := range res.Data {
+					containsMovement(t, createdMovements, data)
+				}
 			} else {
 				assert.Error(t, err)
 				assert.ErrorAs(t, err, &tt.ExpectedErr, "Wanted: %v\nGot: %v", tt.ExpectedErr, err)
-				for _, data := range res.Data {
-					assert.Contains(t, createdMovements, data)
-				}
 			}
 		})
 	}

--- a/repository/movement_repo_test.go
+++ b/repository/movement_repo_test.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"encoding/json"
 	"strconv"
 	"testing"
 	"time"
@@ -368,13 +369,15 @@ func checkEqualMovement(t *testing.T, expected models.Movement, got models.Movem
 	assert.WithinDuration(t, expected.UpdatedAt, got.UpdatedAt, 10*time.Second)
 }
 
-func containsMovement(t *testing.T, expectedList []models.Movement, got models.Movement) bool {
+func containsMovement(t *testing.T, expectedList []models.Movement, got models.Movement) {
 	for _, elem := range expectedList {
 		if compareMovements(elem, got) {
-			return true
+			return
 		}
 	}
-	return false
+	bList, _ := json.MarshalIndent(expectedList, "", " ")
+	dList, _ := json.MarshalIndent(got, "", " ")
+	t.Fatalf("List\n%v\ndoes not contain\n%v", string(bList), string(dList))
 }
 
 func compareMovements(expected models.Movement, got models.Movement) bool {

--- a/repository/movement_repo_test.go
+++ b/repository/movement_repo_test.go
@@ -332,7 +332,7 @@ func createTestMovementList(t *testing.T, client *firestore.Client, sourceID str
 			Name:         "Test movement N" + strconv.Itoa(i),
 			OwnerId:      "0",
 			SourceID:     sourceID,
-			MovementDate: time.Now().AddDate(0, 0, -i),
+			MovementDate: time.Now().AddDate(0, 0, -i).UTC().Truncate(time.Hour * 24),
 		})
 		if err != nil {
 			t.Fatalf("Cant connect to Firestore to create test movement: %s", err.Error())

--- a/repository/movement_repo_test.go
+++ b/repository/movement_repo_test.go
@@ -367,3 +367,60 @@ func checkEqualMovement(t *testing.T, expected models.Movement, got models.Movem
 	assert.WithinDuration(t, expected.CreatedAt, got.CreatedAt, 10*time.Second)
 	assert.WithinDuration(t, expected.UpdatedAt, got.UpdatedAt, 10*time.Second)
 }
+
+func containsMovement(t *testing.T, expectedList []models.Movement, got models.Movement) bool {
+	for _, elem := range expectedList {
+		if compareMovements(elem, got) {
+			return true
+		}
+	}
+	return false
+}
+
+func compareMovements(expected models.Movement, got models.Movement) bool {
+	if expected.UID != got.UID {
+		return false
+	}
+	if expected.OwnerId != got.OwnerId {
+		return false
+	}
+	if expected.SourceID != got.SourceID {
+		return false
+	}
+	if expected.Name != got.Name {
+		return false
+	}
+	if expected.Description != got.Description {
+		return false
+	}
+	if expected.Amount != got.Amount {
+		return false
+	}
+	if !expected.MovementDate.Equal(got.MovementDate) {
+		return false
+	}
+	if !compareStringSlices(expected.Tags, got.Tags) {
+		return false
+	}
+
+	delta := expected.CreatedAt.Sub(got.CreatedAt)
+
+	if delta > time.Second*10 {
+		return false
+	}
+
+	delta = expected.UpdatedAt.Sub(got.UpdatedAt)
+	return delta <= time.Second*10
+}
+
+func compareStringSlices(slice1, slice2 []string) bool {
+	if len(slice1) != len(slice2) {
+		return false
+	}
+	for i := range slice1 {
+		if slice1[i] != slice2[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/repository/movement_repo_test.go
+++ b/repository/movement_repo_test.go
@@ -88,14 +88,18 @@ func Test_movementRepositoryImplementation_CreateNewMovement(t *testing.T) {
 				assert.ErrorAs(t, err, &tt.ExpectedErr, "Expected error as: %s", tt.ExpectedErr.Error())
 			}
 			defer func() {
-				args := map[string]interface{}{
-					"Collection": "movements",
-					"id":         res.UID,
-				}
-				test_utils.ClearFireStoreTest(firestoreClient, "Create", args)
+				deleteTestMovement(firestoreClient, res.UID)
 			}()
 		})
 	}
 	deleteTestUser(firestoreClient)
 	deleteTestSource(firestoreClient, sourceID)
+}
+
+func deleteTestMovement(client *firestore.Client, id string) {
+	args := map[string]interface{}{
+		"Collection": "movements",
+		"id":         id,
+	}
+	test_utils.ClearFireStoreTest(client, "Create", args)
 }

--- a/repository/movement_repo_test.go
+++ b/repository/movement_repo_test.go
@@ -225,7 +225,7 @@ func createTestMovementList(t *testing.T, client *firestore.Client, sourceID str
 			Name:         "Test movement N" + strconv.Itoa(i),
 			OwnerId:      "0",
 			SourceID:     sourceID,
-			MovementDate: time.Now(),
+			MovementDate: time.Now().AddDate(0, 0, i),
 		})
 		if err != nil {
 			t.Fatalf("Cant connect to Firestore to create test movement: %s", err.Error())

--- a/repository/movement_repo_test.go
+++ b/repository/movement_repo_test.go
@@ -235,6 +235,12 @@ func createTestMovementList(t *testing.T, client *firestore.Client, sourceID str
 	return movementList
 }
 
+func deleteTestMovementList(client *firestore.Client, movements []models.Movement) {
+	for _, movement := range movements {
+		deleteTestMovement(client, movement.UID)
+	}
+}
+
 func deleteTestMovement(client *firestore.Client, id string) {
 	args := map[string]interface{}{
 		"Collection": "movements",

--- a/repository/movement_repo_test.go
+++ b/repository/movement_repo_test.go
@@ -1,0 +1,101 @@
+package repository
+
+import (
+	"testing"
+
+	"cloud.google.com/go/firestore"
+	"github.com/AndresCRamos/midas-app-api/models"
+	error_utils "github.com/AndresCRamos/midas-app-api/utils/errors"
+	test_utils "github.com/AndresCRamos/midas-app-api/utils/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_movementRepositoryImplementation_CreateNewMovement(t *testing.T) {
+	firestoreClient := test_utils.InitTestingFireStore(t)
+	firestoreClientFail := test_utils.InitTestingFireStoreFail(t)
+
+	createTestOwner(t, firestoreClient)
+	sourceID := createTestSource(t, firestoreClient)
+
+	tests := []test_utils.TestCase{
+		{
+			Name: "Success",
+			Fields: test_utils.Fields{
+				"firestoreClient": firestoreClient,
+			},
+			Args: test_utils.Args{
+				"movement": models.Movement{UID: "0", Name: "TestMovement", OwnerId: "0", SourceID: sourceID},
+			},
+			WantErr:     false,
+			ExpectedErr: nil,
+			PreTest:     nil,
+		},
+		{
+			Name: "Fail to connect",
+			Fields: test_utils.Fields{
+				"firestoreClient": firestoreClientFail,
+			},
+			Args: test_utils.Args{
+				"movement": models.Movement{},
+			},
+			WantErr:     true,
+			ExpectedErr: error_utils.FirebaseUnknownError{},
+			PreTest:     nil,
+		},
+		{
+			Name: "Cant find owner",
+			Fields: test_utils.Fields{
+				"firestoreClient": firestoreClient,
+			},
+			Args: test_utils.Args{
+				"movement": models.Movement{UID: "0", Name: "TestMovement", OwnerId: "1", SourceID: sourceID},
+			},
+			WantErr:     true,
+			ExpectedErr: error_utils.MovementOwnerNotFound{MovementID: "0", OwnerId: "1"},
+			PreTest:     nil,
+		},
+		{
+			Name: "Cant find source",
+			Fields: test_utils.Fields{
+				"firestoreClient": firestoreClient,
+			},
+			Args: test_utils.Args{
+				"movement": models.Movement{UID: "0", Name: "TestMovement", OwnerId: "0", SourceID: "not_found"},
+			},
+			WantErr:     true,
+			ExpectedErr: error_utils.MovementSourceNotFound{MovementID: "0", SourceID: "not_found"},
+			PreTest:     nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+
+			if tt.PreTest != nil {
+				tt.PreTest(t)
+			}
+			testFirestoreClient := test_utils.GetFieldByNameAndType[*firestore.Client](t, tt.Fields, "firestoreClient")
+			r := &movementRepositoryImplementation{
+				client: testFirestoreClient,
+			}
+			movementTest := test_utils.GetArgByNameAndType[models.Movement](t, tt.Args, "movement")
+			res, err := r.CreateNewMovement(movementTest)
+			if !tt.WantErr {
+				assert.NoError(t, err)
+				assert.Equal(t, movementTest.Name, res.Name)
+				assert.Equal(t, movementTest.Description, res.Description)
+			} else {
+				assert.ErrorAs(t, err, &tt.ExpectedErr, "Expected error as: %s", tt.ExpectedErr.Error())
+			}
+			defer func() {
+				args := map[string]interface{}{
+					"Collection": "movements",
+					"id":         res.UID,
+				}
+				test_utils.ClearFireStoreTest(firestoreClient, "Create", args)
+			}()
+		})
+	}
+	deleteTestUser(firestoreClient)
+	deleteTestSource(firestoreClient, sourceID)
+}

--- a/repository/movement_repo_test.go
+++ b/repository/movement_repo_test.go
@@ -269,6 +269,20 @@ func Test_movementRepositoryImplementation_GetMovementsByUserAndDate(t *testing.
 			ExpectedErr: nil,
 			PreTest:     nil,
 		},
+		{
+			Name:   "Date Limit",
+			Fields: testFields,
+			Args: test_utils.Args{
+				"userID":           "0",
+				"page":             1,
+				"expectedPageSize": 30,
+				"date_from":        time.Now().Add(-30 * 24 * time.Hour),
+				"date_to":          time.Now(),
+			},
+			WantErr:     false,
+			ExpectedErr: nil,
+			PreTest:     nil,
+		},
 	}
 
 	for _, tt := range tests {

--- a/repository/movement_repo_test.go
+++ b/repository/movement_repo_test.go
@@ -514,6 +514,7 @@ func Test_movementRepositoryImplementation_DeleteMovement(t *testing.T) {
 			}
 		})
 	}
+	deleteTestSource(firestoreClient, createdSourceID)
 	deleteTestUser(firestoreClient)
 }
 

--- a/repository/movement_repo_test.go
+++ b/repository/movement_repo_test.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
@@ -211,6 +212,27 @@ func createTestMovement(t *testing.T, client *firestore.Client, sourceID string)
 	}
 
 	return res
+}
+
+func createTestMovementList(t *testing.T, client *firestore.Client, sourceID string) []models.Movement {
+	movementRepo := movementRepositoryImplementation{
+		client: client,
+	}
+	var movementList []models.Movement
+
+	for i := 0; i < 52; i++ {
+		createdMovement, err := movementRepo.CreateNewMovement(models.Movement{
+			Name:         "Test movement N" + strconv.Itoa(i),
+			OwnerId:      "0",
+			SourceID:     sourceID,
+			MovementDate: time.Now(),
+		})
+		if err != nil {
+			t.Fatalf("Cant connect to Firestore to create test movement: %s", err.Error())
+		}
+		movementList = append(movementList, createdMovement)
+	}
+	return movementList
 }
 
 func deleteTestMovement(client *firestore.Client, id string) {

--- a/services/movement_service.go
+++ b/services/movement_service.go
@@ -20,5 +20,5 @@ func NewMovementService(r repository.MovementRepository) *movementServiceImpleme
 }
 
 func (s *movementServiceImplementation) GetMovementByID(id string) (models.Movement, error) {
-	return s.r.GetMovementByID(id)
+	return s.r.GetMovementByID(id, "")
 }

--- a/utils/errors/movement.go
+++ b/utils/errors/movement.go
@@ -1,0 +1,157 @@
+package errors
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	MOVEMENT_ALREADY_EXISTS    = "A movement with id %s already exists"
+	MOVEMENT_NOT_FOUND         = "A movement with id %s doesn't exists"
+	MOVEMENT_OWNER_NOT_FOUND   = "The movement %s cant be created, because owner %s doesn't exists"
+	MOVEMENT_OWNER_CANT_CHANGE = "The provided owner %s of movement %s is not the current one"
+	MOVEMENT_NOT_OWNER         = "The user %s is not the owner of movement %s"
+	MOVEMENT_NOT_ENOUGH_DATA   = "Requested movement page does not exists"
+)
+
+const (
+	movement_repository_error = "MovementRepository: %s"
+	movement_service_error    = "MovementService: %s: %s"
+)
+
+// MovementRepositoryError struct
+type MovementRepositoryError struct {
+	Err error
+}
+
+func (sre MovementRepositoryError) Error() string {
+	return fmt.Sprintf(movement_repository_error, sre.Err.Error())
+}
+
+func (sre *MovementRepositoryError) Wrap(err error) {
+	sre.Err = err
+}
+
+func (sre MovementRepositoryError) Unwrap() error {
+	return sre.Err
+}
+
+// MovementServiceError struct
+type MovementServiceError struct {
+	Method string
+	Err    error
+}
+
+func (sse MovementServiceError) Error() string {
+	MethodMsg := ""
+	switch sse.Method {
+	case "Create":
+		MethodMsg = "Cant create"
+	case "Retrieve":
+		MethodMsg = "Cant retrieve"
+	case "List":
+		MethodMsg = "Cant get list"
+	case "Update":
+		MethodMsg = "Cant update"
+	case "Delete":
+		MethodMsg = "Cant delete"
+	default:
+		MethodMsg = "Unknown method"
+	}
+	return fmt.Sprintf(movement_service_error, MethodMsg, sse.Err.Error())
+}
+
+func (sse *MovementServiceError) Wrap(err error) {
+	sse.Err = err
+}
+
+func (sse MovementServiceError) Unwrap() error {
+	return sse.Err
+}
+
+type MovementDuplicated struct {
+	MovementID string
+}
+
+func (sd MovementDuplicated) GetAPIError() (int, gin.H) {
+	return http.StatusBadRequest, gin.H{
+		"error": fmt.Sprintf(MOVEMENT_ALREADY_EXISTS, sd.MovementID),
+	}
+}
+
+func (sd MovementDuplicated) Error() string {
+	return fmt.Sprintf(MOVEMENT_ALREADY_EXISTS, sd.MovementID)
+}
+
+type MovementNotFound struct {
+	MovementID string
+}
+
+func (snf MovementNotFound) GetAPIError() (int, gin.H) {
+	return http.StatusNotFound, gin.H{
+		"error": fmt.Sprintf(MOVEMENT_NOT_FOUND, snf.MovementID),
+	}
+}
+
+func (snf MovementNotFound) Error() string {
+	return fmt.Sprintf(MOVEMENT_NOT_FOUND, snf.MovementID)
+}
+
+type MovementOwnerNotFound struct {
+	MovementID string
+	OwnerId    string
+}
+
+func (onf MovementOwnerNotFound) GetAPIError() (int, gin.H) {
+	return http.StatusNotFound, gin.H{
+		"error": fmt.Sprintf(OWNER_NOT_FOUND, onf.MovementID, onf.OwnerId),
+	}
+}
+
+func (onf MovementOwnerNotFound) Error() string {
+	return fmt.Sprintf(OWNER_NOT_FOUND, onf.MovementID, onf.OwnerId)
+}
+
+type MovementCantChangeOwner struct {
+	MovementID string
+	OwnerID    string
+}
+
+func (sco MovementCantChangeOwner) GetAPIError() (int, gin.H) {
+	return http.StatusNotFound, gin.H{
+		"error": fmt.Sprintf(OWNER_CANT_CHANGE, sco.OwnerID, sco.MovementID),
+	}
+}
+
+func (sco MovementCantChangeOwner) Error() string {
+	return fmt.Sprintf(OWNER_CANT_CHANGE, sco.OwnerID, sco.MovementID)
+}
+
+type MovementDifferentOwner struct {
+	MovementID string
+	OwnerID    string
+}
+
+func (sdo MovementDifferentOwner) GetAPIError() (int, gin.H) {
+	return http.StatusNotFound, gin.H{
+		"error": fmt.Sprintf(MOVEMENT_NOT_OWNER, sdo.OwnerID, sdo.MovementID),
+	}
+}
+
+func (sdo MovementDifferentOwner) Error() string {
+	return fmt.Sprintf(MOVEMENT_NOT_OWNER, sdo.OwnerID, sdo.MovementID)
+}
+
+type MovementNotEnoughData struct{}
+
+func (sne MovementNotEnoughData) GetAPIError() (int, gin.H) {
+	return http.StatusNotFound, gin.H{
+		"error": MOVEMENT_NOT_ENOUGH_DATA,
+	}
+}
+
+func (sne MovementNotEnoughData) Error() string {
+	return MOVEMENT_NOT_ENOUGH_DATA
+}

--- a/utils/errors/movement.go
+++ b/utils/errors/movement.go
@@ -11,6 +11,7 @@ const (
 	MOVEMENT_ALREADY_EXISTS    = "A movement with id %s already exists"
 	MOVEMENT_NOT_FOUND         = "A movement with id %s doesn't exists"
 	MOVEMENT_OWNER_NOT_FOUND   = "The movement %s cant be created, because owner %s doesn't exists"
+	MOVEMENT_SOURCE_NOT_FOUND  = "The movement %s cant be created, because source %s doesn't exists"
 	MOVEMENT_OWNER_CANT_CHANGE = "The provided owner %s of movement %s is not the current one"
 	MOVEMENT_NOT_OWNER         = "The user %s is not the owner of movement %s"
 	MOVEMENT_NOT_ENOUGH_DATA   = "Requested movement page does not exists"
@@ -142,6 +143,21 @@ func (sdo MovementDifferentOwner) GetAPIError() (int, gin.H) {
 
 func (sdo MovementDifferentOwner) Error() string {
 	return fmt.Sprintf(MOVEMENT_NOT_OWNER, sdo.OwnerID, sdo.MovementID)
+}
+
+type MovementSourceNotFound struct {
+	MovementID string
+	SourceID   string
+}
+
+func (smn MovementSourceNotFound) GetAPIError() (int, gin.H) {
+	return http.StatusNotFound, gin.H{
+		"error": fmt.Sprintf(MOVEMENT_SOURCE_NOT_FOUND, smn.MovementID, smn.SourceID),
+	}
+}
+
+func (smn MovementSourceNotFound) Error() string {
+	return fmt.Sprintf(MOVEMENT_SOURCE_NOT_FOUND, smn.MovementID, smn.SourceID)
 }
 
 type MovementNotEnoughData struct{}

--- a/utils/firebase/search.go
+++ b/utils/firebase/search.go
@@ -1,0 +1,25 @@
+package firebase
+
+import (
+	"context"
+
+	"cloud.google.com/go/firestore"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func CheckDocumentExists(collection *firestore.CollectionRef, id string) (bool, error) {
+	docRef, err := collection.Doc(id).Get(context.Background())
+	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			return false, nil
+		}
+		return false, err
+	}
+	if docRef == nil && !docRef.Exists() {
+		return false, nil
+	}
+
+	return true, nil
+
+}


### PR DESCRIPTION
# Movements Repository

An interface to interact with the saved movements using the following methods:

## CreateNewMovement
`CreateNewMovement(movement models.Movement) (models.Movement, error)`
Creates a new movement using the _movement_ parameter and returns it, along with any possible error

## GetMovementByID
`GetMovementByID(id string, userID string) (models.Movement, error)`
Gets a movement with the same _id_, and checks if the owner of that movement is the same as the _userID_ passed, if true, the data is returned, if not, an error is returned
 
## GetMovementsByUserAndDate
`GetMovementsByUserAndDate(userID string, page int, from_date time.Time, to_date time.Time)(util_models.PaginatedSearch[models.Movement], error)`
It searches all movements made by a user between the _from_date_ and _to_date_ parameters, paginating the response and returning a _PaginatedSearch[models.Movement]_ struct with the page specified by the _page_ parameter

## UpdateMovement
`UpdateMovement(movement models.Movement) (models.Movement, error)`
It takes a movement as a parameter, and searches its _movement.UID_ field, if found, then checks if the movement.OwnerID is the same as the retrieved one, if not, returns an error, if yes, merges the new data with the old one

## DeleteMovement
`DeleteMovement(id string, userID string) error`
Searches for a movement with the _id_ specified, and checks if the owner is the same as the _userID_ provided, if not, returns an error, if yes, it deletes it

Other implemented changes include:
- Add tests for all movement repo functions
- Add firestore struct tags for movement
- Add movement related errors
- Add checkDocumentExists function
