### PR TITLE
Feature/get movements by source

### DIFF
--- a/handlers/source_handler.go
+++ b/handlers/source_handler.go
@@ -120,7 +120,7 @@ func (h *sourceHandler) GetMovementsBySourceAndDate(c *gin.Context) {
 	dateToStr, exists := c.GetQuery("date_to")
 	var dateTo time.Time
 	if !exists {
-		dateFrom = time.Now().UTC()
+		dateTo = time.Now().UTC()
 	} else if dateTo, err = time.Parse(time.DateOnly, dateToStr); err != nil {
 		c.AbortWithStatusJSON(http.StatusBadRequest, err)
 		return

--- a/handlers/source_handler.go
+++ b/handlers/source_handler.go
@@ -113,7 +113,7 @@ func (h *sourceHandler) GetMovementsBySourceAndDate(c *gin.Context) {
 	if !exists {
 		dateFrom = time.Now().UTC().Add(-30 * 24 * time.Hour)
 	} else if dateFrom, err = time.Parse(time.DateOnly, dateFromStr); err != nil {
-		c.AbortWithStatusJSON(http.StatusBadRequest, err)
+		c.AbortWithStatusJSON(error_utils.SourceBadDateFormat{DateString: dateFromStr, DateField: "date_from", Format: time.DateOnly}.GetAPIError())
 		return
 	}
 
@@ -122,7 +122,7 @@ func (h *sourceHandler) GetMovementsBySourceAndDate(c *gin.Context) {
 	if !exists {
 		dateTo = time.Now().UTC()
 	} else if dateTo, err = time.Parse(time.DateOnly, dateToStr); err != nil {
-		c.AbortWithStatusJSON(http.StatusBadRequest, err)
+		c.AbortWithStatusJSON(error_utils.SourceBadDateFormat{DateString: dateToStr, DateField: "date_to", Format: time.DateOnly}.GetAPIError())
 		return
 	}
 

--- a/handlers/source_handler.go
+++ b/handlers/source_handler.go
@@ -108,8 +108,7 @@ func (h *sourceHandler) GetMovementsBySourceAndDate(c *gin.Context) {
 		return
 	}
 
-	dateFromStr, exists := c.GetQuery("page")
-
+	dateFromStr, exists := c.GetQuery("date_from")
 	var dateFrom time.Time
 	if !exists {
 		dateFrom = time.Now().UTC().Add(-30 * 24 * time.Hour)
@@ -118,10 +117,11 @@ func (h *sourceHandler) GetMovementsBySourceAndDate(c *gin.Context) {
 		return
 	}
 
+	dateToStr, exists := c.GetQuery("date_to")
 	var dateTo time.Time
 	if !exists {
 		dateFrom = time.Now().UTC()
-	} else if dateTo, err = time.Parse(time.DateOnly, dateFromStr); err != nil {
+	} else if dateTo, err = time.Parse(time.DateOnly, dateToStr); err != nil {
 		c.AbortWithStatusJSON(http.StatusBadRequest, err)
 		return
 	}

--- a/handlers/source_handler_test.go
+++ b/handlers/source_handler_test.go
@@ -421,7 +421,7 @@ func Test_sourceHandler_GetMovementsBySourceAndDate(t *testing.T) {
 				"date_to":      "bad_date",
 			},
 			WantErr:     true,
-			ExpectedErr: error_utils.MovementBadDates{},
+			ExpectedErr: error_utils.SourceBadDateFormat{DateString: "bad_date", DateField: "date_to", Format: time.DateOnly},
 			PreTest:     nil,
 		},
 	}

--- a/handlers/source_handler_test.go
+++ b/handlers/source_handler_test.go
@@ -412,6 +412,18 @@ func Test_sourceHandler_GetMovementsBySourceAndDate(t *testing.T) {
 			ExpectedErr: error_utils.MovementBadDates{},
 			PreTest:     nil,
 		},
+		{
+			Name:   "Syntax date to error",
+			Fields: fields,
+			Args: test_utils.Args{
+				"sourceID":     "5",
+				"expectedCode": http.StatusBadRequest,
+				"date_to":      "bad_date",
+			},
+			WantErr:     true,
+			ExpectedErr: error_utils.MovementBadDates{},
+			PreTest:     nil,
+		},
 	}
 
 	for _, tt := range tests {

--- a/handlers/source_handler_test.go
+++ b/handlers/source_handler_test.go
@@ -414,6 +414,9 @@ func Test_sourceHandler_GetMovementsBySourceAndDate(t *testing.T) {
 			}
 
 			sourceID := test_utils.GetArgByNameAndType[string](t, tt.Args, "sourceID")
+			page, _ := test_utils.ShouldGetArgByNameAndType[string](tt.Args, "page")
+			date_from, _ := test_utils.ShouldGetArgByNameAndType[string](tt.Args, "date_from")
+			date_to, _ := test_utils.ShouldGetArgByNameAndType[string](tt.Args, "date_from")
 
 			testRequest := test.TestRequest{
 				Method:      http.MethodGet,
@@ -421,6 +424,11 @@ func Test_sourceHandler_GetMovementsBySourceAndDate(t *testing.T) {
 				RequestPath: "/" + sourceID,
 				Handler:     h.GetMovementsBySourceAndDate,
 				Middlewares: []gin.HandlerFunc{test_middleware.TestMiddleware("123")},
+				QueryParams: map[string]string{
+					"page":      page,
+					"date_from": date_from,
+					"date_to":   date_to,
+				},
 			}
 
 			w := testRequest.ServeRequest(t)

--- a/handlers/source_handler_test.go
+++ b/handlers/source_handler_test.go
@@ -424,6 +424,18 @@ func Test_sourceHandler_GetMovementsBySourceAndDate(t *testing.T) {
 			ExpectedErr: error_utils.SourceBadDateFormat{DateString: "bad_date", DateField: "date_to", Format: time.DateOnly},
 			PreTest:     nil,
 		},
+		{
+			Name:   "Syntax date from error",
+			Fields: fields,
+			Args: test_utils.Args{
+				"sourceID":     "5",
+				"expectedCode": http.StatusBadRequest,
+				"date_from":    "bad_date",
+			},
+			WantErr:     true,
+			ExpectedErr: error_utils.SourceBadDateFormat{DateString: "bad_date", DateField: "date_from", Format: time.DateOnly},
+			PreTest:     nil,
+		},
 	}
 
 	for _, tt := range tests {

--- a/handlers/source_handler_test.go
+++ b/handlers/source_handler_test.go
@@ -401,6 +401,17 @@ func Test_sourceHandler_GetMovementsBySourceAndDate(t *testing.T) {
 			ExpectedErr: error_utils.SourceNotFound{SourceID: "2"},
 			PreTest:     nil,
 		},
+		{
+			Name:   "Bad dates",
+			Fields: fields,
+			Args: test_utils.Args{
+				"sourceID":     "5",
+				"expectedCode": http.StatusBadRequest,
+			},
+			WantErr:     true,
+			ExpectedErr: error_utils.MovementBadDates{},
+			PreTest:     nil,
+		},
 	}
 
 	for _, tt := range tests {

--- a/handlers/source_handler_test.go
+++ b/handlers/source_handler_test.go
@@ -439,7 +439,7 @@ func Test_sourceHandler_GetMovementsBySourceAndDate(t *testing.T) {
 			sourceID := test_utils.GetArgByNameAndType[string](t, tt.Args, "sourceID")
 			page, _ := test_utils.ShouldGetArgByNameAndType[string](tt.Args, "page")
 			date_from, _ := test_utils.ShouldGetArgByNameAndType[string](tt.Args, "date_from")
-			date_to, _ := test_utils.ShouldGetArgByNameAndType[string](tt.Args, "date_from")
+			date_to, _ := test_utils.ShouldGetArgByNameAndType[string](tt.Args, "date_to")
 
 			testRequest := test.TestRequest{
 				Method:      http.MethodGet,

--- a/routes/source_routes.go
+++ b/routes/source_routes.go
@@ -23,6 +23,7 @@ func addSourceRoutes(server *server.Server) {
 		sourceGroup.GET("/", handler.GetSourcesByUser)
 		sourceGroup.POST("/", handler.CreateNewSource)
 		sourceGroup.GET("/:id", handler.GetSourceByID)
+		sourceGroup.GET("/:id/movements", handler.GetMovementsBySourceAndDate)
 		sourceGroup.PUT("/:id", handler.UpdateSource)
 		sourceGroup.DELETE("/:id", handler.DeleteSource)
 	}

--- a/services/source_service.go
+++ b/services/source_service.go
@@ -1,6 +1,8 @@
 package services
 
 import (
+	"time"
+
 	"github.com/AndresCRamos/midas-app-api/models"
 	"github.com/AndresCRamos/midas-app-api/repository"
 	util_models "github.com/AndresCRamos/midas-app-api/utils/api/models"
@@ -11,6 +13,7 @@ type SourceService interface {
 	CreateNewSource(Source models.Source) (models.Source, error)
 	GetSourceByID(id string, userID string) (models.Source, error)
 	GetSourcesByUser(userID string, page int) (util_models.PaginatedSearch[models.Source], error)
+	GetMovementsBySourceAndDate(id string, userID string, page int, date_from time.Time, date_to time.Time) (util_models.PaginatedSearch[models.Movement], error)
 	UpdateSource(Source models.Source) (models.Source, error)
 	DeleteSource(id string, userID string) error
 }
@@ -41,6 +44,15 @@ func (s *sourceServiceImplementation) GetSourcesByUser(userID string, page int) 
 		return util_models.PaginatedSearch[models.Source]{}, sourceServiceErr
 	}
 	return source, nil
+}
+
+func (s *sourceServiceImplementation) GetMovementsBySourceAndDate(id string, userID string, page int, date_from time.Time, date_to time.Time) (util_models.PaginatedSearch[models.Movement], error) {
+	movementData, err := s.r.GetMovementsBySourceAndDate(id, userID, page, date_from, date_to)
+	if err != nil {
+		return util_models.PaginatedSearch[models.Movement]{}, error_utils.SourceServiceError{Err: err, Method: "List"}
+	}
+
+	return movementData, err
 }
 
 func (s *sourceServiceImplementation) GetSourceByID(id string, userID string) (models.Source, error) {

--- a/utils/errors/source.go
+++ b/utils/errors/source.go
@@ -14,6 +14,7 @@ const (
 	OWNER_CANT_CHANGE      = "The provided owner %s of source %s is not the current one"
 	SOURCE_NOT_OWNER       = "The user %s is not the owner of source %s"
 	SOURCE_NOT_ENOUGH_DATA = "Requested source page does not exists"
+	SOURCE_BAD_DATE_FORMAT = "%s value %s must be of format %s"
 )
 
 const (
@@ -166,4 +167,20 @@ func (sne SourceBadDates) GetAPIError() (int, gin.H) {
 
 func (sne SourceBadDates) Error() string {
 	return MOVEMENT_BAD_DATES
+}
+
+type SourceBadDateFormat struct {
+	DateString string
+	DateField  string
+	Format     string
+}
+
+func (sbf SourceBadDateFormat) GetAPIError() (int, gin.H) {
+	return http.StatusBadRequest, gin.H{
+		"error": fmt.Sprintf(SOURCE_BAD_DATE_FORMAT, sbf.DateField, sbf.DateString, sbf.Format),
+	}
+}
+
+func (sbf SourceBadDateFormat) Error() string {
+	return fmt.Sprintf(SOURCE_BAD_DATE_FORMAT, sbf.DateField, sbf.DateString, sbf.Format)
 }

--- a/utils/errors/source.go
+++ b/utils/errors/source.go
@@ -155,3 +155,15 @@ func (sne SourceNotEnoughData) GetAPIError() (int, gin.H) {
 func (sne SourceNotEnoughData) Error() string {
 	return SOURCE_NOT_ENOUGH_DATA
 }
+
+type SourceBadDates struct{}
+
+func (sne SourceBadDates) GetAPIError() (int, gin.H) {
+	return http.StatusNotFound, gin.H{
+		"error": MOVEMENT_BAD_DATES,
+	}
+}
+
+func (sne SourceBadDates) Error() string {
+	return MOVEMENT_BAD_DATES
+}

--- a/utils/errors/source.go
+++ b/utils/errors/source.go
@@ -159,7 +159,7 @@ func (sne SourceNotEnoughData) Error() string {
 type SourceBadDates struct{}
 
 func (sne SourceBadDates) GetAPIError() (int, gin.H) {
-	return http.StatusNotFound, gin.H{
+	return http.StatusBadRequest, gin.H{
 		"error": MOVEMENT_BAD_DATES,
 	}
 }

--- a/utils/test/mocks/source_repo.go
+++ b/utils/test/mocks/source_repo.go
@@ -1,12 +1,43 @@
 package mocks
 
 import (
+	"time"
+
 	"github.com/AndresCRamos/midas-app-api/models"
 	util_models "github.com/AndresCRamos/midas-app-api/utils/api/models"
 	error_const "github.com/AndresCRamos/midas-app-api/utils/errors"
 )
 
 type SourceRepositoryMock struct{}
+
+func (r SourceRepositoryMock) GetMovementsBySourceAndDate(id string, userID string, page int, date_from time.Time, date_to time.Time) (util_models.PaginatedSearch[models.Movement], error) {
+	wrapper := error_const.SourceRepositoryError{}
+	switch userID {
+	case "0":
+		return util_models.PaginatedSearch[models.Movement]{
+			CurrentPage: 1,
+			TotalData:   1,
+			PageSize:    1,
+			Data: []models.Movement{
+				TestMovement,
+			},
+		}, nil
+	case "1":
+		wrapper.Wrap(error_const.FirebaseUnknownError{})
+		return util_models.PaginatedSearch[models.Movement]{}, wrapper
+	case "2":
+		wrapper.Wrap(error_const.SourceNotFound{})
+		return util_models.PaginatedSearch[models.Movement]{}, wrapper
+	case "3":
+		wrapper.Wrap(error_const.SourceDifferentOwner{})
+		return util_models.PaginatedSearch[models.Movement]{}, wrapper
+	case "4":
+		wrapper.Wrap(error_const.MovementNotEnoughData{})
+		return util_models.PaginatedSearch[models.Movement]{}, wrapper
+	default:
+		return util_models.PaginatedSearch[models.Movement]{}, error_const.TestInvalidTestCaseError{Param: userID}
+	}
+}
 
 func (r SourceRepositoryMock) CreateNewSource(source models.Source) (models.Source, error) {
 	wrapper := error_const.SourceRepositoryError{}

--- a/utils/test/mocks/source_service.go
+++ b/utils/test/mocks/source_service.go
@@ -82,6 +82,9 @@ func (r SourceServiceMock) GetMovementsBySourceAndDate(id string, userID string,
 	case "4":
 		RepoWrapper.Wrap(error_const.MovementNotEnoughData{})
 		return util_models.PaginatedSearch[models.Movement]{}, wrapper
+	case "5":
+		RepoWrapper.Wrap(error_const.SourceBadDates{})
+		return util_models.PaginatedSearch[models.Movement]{}, wrapper
 	default:
 		return util_models.PaginatedSearch[models.Movement]{}, error_const.TestInvalidTestCaseError{Param: userID}
 	}

--- a/utils/test/mocks/source_service.go
+++ b/utils/test/mocks/source_service.go
@@ -1,6 +1,8 @@
 package mocks
 
 import (
+	"time"
+
 	"github.com/AndresCRamos/midas-app-api/models"
 	util_models "github.com/AndresCRamos/midas-app-api/utils/api/models"
 	error_const "github.com/AndresCRamos/midas-app-api/utils/errors"
@@ -52,6 +54,38 @@ func (r SourceServiceMock) GetSourcesByUser(userID string, page int) (util_model
 	default:
 		return util_models.PaginatedSearch[models.Source]{}, error_const.TestInvalidTestCaseError{Param: userID}
 	}
+}
+
+func (r SourceServiceMock) GetMovementsBySourceAndDate(id string, userID string, page int, date_from time.Time, date_to time.Time) (util_models.PaginatedSearch[models.Movement], error) {
+	RepoWrapper := &error_const.SourceRepositoryError{}
+	wrapper := &error_const.SourceServiceError{}
+	wrapper.Wrap(RepoWrapper)
+	switch id {
+	case "0":
+		return util_models.PaginatedSearch[models.Movement]{
+			CurrentPage: 1,
+			TotalData:   1,
+			PageSize:    1,
+			Data: []models.Movement{
+				TestMovement,
+			},
+		}, nil
+	case "1":
+		RepoWrapper.Wrap(error_const.FirebaseUnknownError{})
+		return util_models.PaginatedSearch[models.Movement]{}, wrapper
+	case "2":
+		RepoWrapper.Wrap(error_const.SourceNotFound{SourceID: id})
+		return util_models.PaginatedSearch[models.Movement]{}, wrapper
+	case "3":
+		RepoWrapper.Wrap(error_const.SourceDifferentOwner{SourceID: id, OwnerID: userID})
+		return util_models.PaginatedSearch[models.Movement]{}, wrapper
+	case "4":
+		RepoWrapper.Wrap(error_const.MovementNotEnoughData{})
+		return util_models.PaginatedSearch[models.Movement]{}, wrapper
+	default:
+		return util_models.PaginatedSearch[models.Movement]{}, error_const.TestInvalidTestCaseError{Param: userID}
+	}
+
 }
 
 func (r SourceServiceMock) GetSourceByID(id string, userId string) (models.Source, error) {

--- a/utils/test/request.go
+++ b/utils/test/request.go
@@ -60,7 +60,9 @@ func (te TestRequest) ServeRequest(t *testing.T) *httptest.ResponseRecorder {
 	if te.QueryParams != nil {
 		q := req.URL.Query()
 		for queryParamKey, queryParamVal := range te.QueryParams {
-			q.Add(queryParamKey, queryParamVal)
+			if queryParamVal != "" {
+				q.Add(queryParamKey, queryParamVal)
+			}
 		}
 		req.URL.RawQuery = q.Encode()
 	}


### PR DESCRIPTION
# GetMovementsBySourceAndDate feature

Added a function called GetMovementsBySourceAndDate to Source Repository, Source Service and Source Handler that get all the movements between 2 dates of a single source paginated in groups, taking into account these constraints

- The user must be the owner of the source
- The source must exist
- Date from and date 2 are optional query parameters
  - Date from and date to must be date only
  - Date from must be less that date to
  - If Date from is not specified, is defaulted to today minus 30 days
  - If Date to is not specified, is defaulted to today
- Page is an optional query parameter
  - Must be an integer
  - If not specified, the default value is 1
- The source must have at least 1 movement
  - If not, it returns an error of type MovementNotEnoughData
  
  Other changes include
  - Tests for all implementations
  - New errors
    - SourceBadDates
    - SourceBadDateFormat
