### PR TITLE
Firestore test utils

### DIFF
--- a/repository/movement_repo_test.go
+++ b/repository/movement_repo_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/AndresCRamos/midas-app-api/models"
 	error_utils "github.com/AndresCRamos/midas-app-api/utils/errors"
 	test_utils "github.com/AndresCRamos/midas-app-api/utils/test"
+	firestore_utils "github.com/AndresCRamos/midas-app-api/utils/test/firestore"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -17,8 +18,8 @@ func Test_movementRepositoryImplementation_CreateNewMovement(t *testing.T) {
 	firestoreClient := test_utils.InitTestingFireStore(t)
 	firestoreClientFail := test_utils.InitTestingFireStoreFail(t)
 
-	createTestOwner(t, firestoreClient)
-	sourceID := createTestSource(t, firestoreClient)
+	createdOwner := firestore_utils.CreateTestUser(t, firestoreClient, "0")
+	createdSource := firestore_utils.CreateTestSource(t, firestoreClient, createdOwner.UID)
 
 	tests := []test_utils.TestCase{
 		{
@@ -31,7 +32,7 @@ func Test_movementRepositoryImplementation_CreateNewMovement(t *testing.T) {
 					UID:       "0",
 					Name:      "TestMovement",
 					OwnerId:   "0",
-					SourceID:  sourceID,
+					SourceID:  createdSource.UID,
 					CreatedAt: time.Now(),
 					UpdatedAt: time.Now(),
 				},
@@ -58,7 +59,7 @@ func Test_movementRepositoryImplementation_CreateNewMovement(t *testing.T) {
 				"firestoreClient": firestoreClient,
 			},
 			Args: test_utils.Args{
-				"movement": models.Movement{UID: "0", Name: "TestMovement", OwnerId: "1", SourceID: sourceID},
+				"movement": models.Movement{UID: "0", Name: "TestMovement", OwnerId: "1", SourceID: createdSource.UID},
 			},
 			WantErr:     true,
 			ExpectedErr: error_utils.MovementOwnerNotFound{MovementID: "0", OwnerId: "1"},
@@ -103,8 +104,8 @@ func Test_movementRepositoryImplementation_CreateNewMovement(t *testing.T) {
 			}()
 		})
 	}
-	deleteTestUser(firestoreClient)
-	deleteTestSource(firestoreClient, sourceID)
+	firestore_utils.DeleteTestSource(t, firestoreClient, createdSource.UID)
+	firestore_utils.DeleteTestUser(t, firestoreClient, createdOwner.UID)
 }
 
 func Test_movementRepositoryImplementation_GetMovementByID(t *testing.T) {
@@ -112,9 +113,9 @@ func Test_movementRepositoryImplementation_GetMovementByID(t *testing.T) {
 	firestoreClient := test_utils.InitTestingFireStore(t)
 	firestoreClientFail := test_utils.InitTestingFireStoreFail(t)
 
-	createTestOwner(t, firestoreClient)
-	createdSourceUID := createTestSource(t, firestoreClient)
-	createdMovement := createTestMovement(t, firestoreClient, createdSourceUID)
+	createdOwner := firestore_utils.CreateTestUser(t, firestoreClient, "0")
+	createdSource := firestore_utils.CreateTestSource(t, firestoreClient, createdOwner.UID)
+	createdMovement := createTestMovement(t, firestoreClient, createdSource.UID)
 
 	testFields := test_utils.Fields{
 		"firestoreClient": firestoreClient,
@@ -193,8 +194,8 @@ func Test_movementRepositoryImplementation_GetMovementByID(t *testing.T) {
 		})
 	}
 	deleteTestMovement(firestoreClient, createdMovement.UID)
-	deleteTestSource(firestoreClient, createdSourceUID)
-	deleteTestUser(firestoreClient)
+	firestore_utils.DeleteTestSource(t, firestoreClient, createdSource.UID)
+	firestore_utils.DeleteTestUser(t, firestoreClient, createdOwner.UID)
 }
 
 func Test_movementRepositoryImplementation_GetMovementsByUserAndDate(t *testing.T) {
@@ -202,9 +203,9 @@ func Test_movementRepositoryImplementation_GetMovementsByUserAndDate(t *testing.
 	firestoreClient := test_utils.InitTestingFireStore(t)
 	firestoreClientFail := test_utils.InitTestingFireStoreFail(t)
 
-	createTestOwner(t, firestoreClient)
-	createdSourceID := createTestSource(t, firestoreClient)
-	createdMovements := createTestMovementList(t, firestoreClient, createdSourceID)
+	createdOwner := firestore_utils.CreateTestUser(t, firestoreClient, "0")
+	createdSource := firestore_utils.CreateTestSource(t, firestoreClient, createdOwner.UID)
+	createdMovements := createTestMovementList(t, firestoreClient, createdSource.UID)
 
 	testFields := test_utils.Fields{
 		"firestoreClient": firestoreClient,
@@ -314,17 +315,17 @@ func Test_movementRepositoryImplementation_GetMovementsByUserAndDate(t *testing.
 		})
 	}
 	deleteTestMovementList(firestoreClient, createdMovements)
-	deleteTestSource(firestoreClient, createdSourceID)
-	deleteTestUser(firestoreClient)
+	firestore_utils.DeleteTestSource(t, firestoreClient, createdSource.UID)
+	firestore_utils.DeleteTestUser(t, firestoreClient, createdOwner.UID)
 }
 
 func Test_movementRepositoryImplementation_UpdateMovement(t *testing.T) {
 	firestoreClient := test_utils.InitTestingFireStore(t)
 	firestoreClientFail := test_utils.InitTestingFireStoreFail(t)
 
-	createTestOwner(t, firestoreClient)
-	createdSourceUID := createTestSource(t, firestoreClient)
-	createdMovement := createTestMovement(t, firestoreClient, createdSourceUID)
+	createdOwner := firestore_utils.CreateTestUser(t, firestoreClient, "0")
+	createdSource := firestore_utils.CreateTestSource(t, firestoreClient, createdOwner.UID)
+	createdMovement := createTestMovement(t, firestoreClient, createdSource.UID)
 	updatedMovement := models.Movement{
 		UID:          createdMovement.UID,
 		Name:         "Update Movement",
@@ -426,8 +427,8 @@ func Test_movementRepositoryImplementation_UpdateMovement(t *testing.T) {
 	}
 	defer func() {
 		deleteTestMovement(firestoreClient, createdMovement.UID)
-		deleteTestSource(firestoreClient, createdSourceUID)
-		deleteTestUser(firestoreClient)
+		firestore_utils.DeleteTestSource(t, firestoreClient, createdSource.UID)
+		firestore_utils.DeleteTestUser(t, firestoreClient, createdOwner.UID)
 	}()
 }
 
@@ -436,9 +437,9 @@ func Test_movementRepositoryImplementation_DeleteMovement(t *testing.T) {
 	firestoreClient := test_utils.InitTestingFireStore(t)
 	firestoreClientFail := test_utils.InitTestingFireStoreFail(t)
 
-	createTestOwner(t, firestoreClient)
-	createdSourceID := createTestSource(t, firestoreClient)
-	createdMovement := createTestMovement(t, firestoreClient, createdSourceID)
+	createdOwner := firestore_utils.CreateTestUser(t, firestoreClient, "0")
+	createdSource := firestore_utils.CreateTestSource(t, firestoreClient, createdOwner.UID)
+	createdMovement := createTestMovement(t, firestoreClient, createdSource.UID)
 
 	testFields := test_utils.Fields{
 		"firestoreClient": firestoreClient,
@@ -514,8 +515,8 @@ func Test_movementRepositoryImplementation_DeleteMovement(t *testing.T) {
 			}
 		})
 	}
-	deleteTestSource(firestoreClient, createdSourceID)
-	deleteTestUser(firestoreClient)
+	firestore_utils.DeleteTestSource(t, firestoreClient, createdSource.UID)
+	firestore_utils.DeleteTestUser(t, firestoreClient, createdOwner.UID)
 }
 
 func createTestMovement(t *testing.T, client *firestore.Client, sourceID string) models.Movement {

--- a/repository/movement_repo_test.go
+++ b/repository/movement_repo_test.go
@@ -100,7 +100,7 @@ func Test_movementRepositoryImplementation_CreateNewMovement(t *testing.T) {
 				assert.ErrorAs(t, err, &tt.ExpectedErr, "Expected error as: %s", tt.ExpectedErr.Error())
 			}
 			defer func() {
-				deleteTestMovement(firestoreClient, res.UID)
+				firestore_utils.DeleteTestMovement(t, firestoreClient, res.UID)
 			}()
 		})
 	}
@@ -193,7 +193,7 @@ func Test_movementRepositoryImplementation_GetMovementByID(t *testing.T) {
 			}
 		})
 	}
-	deleteTestMovement(firestoreClient, createdMovement.UID)
+	firestore_utils.DeleteTestMovement(t, firestoreClient, createdMovement.UID)
 	firestore_utils.DeleteTestSource(t, firestoreClient, createdSource.UID)
 	firestore_utils.DeleteTestUser(t, firestoreClient, createdOwner.UID)
 }
@@ -314,7 +314,7 @@ func Test_movementRepositoryImplementation_GetMovementsByUserAndDate(t *testing.
 			}
 		})
 	}
-	deleteTestMovementList(firestoreClient, createdMovements)
+	firestore_utils.DeleteTestMovementList(t, firestoreClient, createdMovements)
 	firestore_utils.DeleteTestSource(t, firestoreClient, createdSource.UID)
 	firestore_utils.DeleteTestUser(t, firestoreClient, createdOwner.UID)
 }
@@ -426,7 +426,7 @@ func Test_movementRepositoryImplementation_UpdateMovement(t *testing.T) {
 		})
 	}
 	defer func() {
-		deleteTestMovement(firestoreClient, createdMovement.UID)
+		firestore_utils.DeleteTestMovement(t, firestoreClient, createdMovement.UID)
 		firestore_utils.DeleteTestSource(t, firestoreClient, createdSource.UID)
 		firestore_utils.DeleteTestUser(t, firestoreClient, createdOwner.UID)
 	}()

--- a/repository/movement_repo_test.go
+++ b/repository/movement_repo_test.go
@@ -2,7 +2,6 @@ package repository
 
 import (
 	"encoding/json"
-	"strconv"
 	"testing"
 	"time"
 
@@ -517,41 +516,6 @@ func Test_movementRepositoryImplementation_DeleteMovement(t *testing.T) {
 	}
 	firestore_utils.DeleteTestSource(t, firestoreClient, createdSource.UID)
 	firestore_utils.DeleteTestUser(t, firestoreClient, createdOwner.UID)
-}
-
-func createTestMovementList(t *testing.T, client *firestore.Client, sourceID string) []models.Movement {
-	movementRepo := movementRepositoryImplementation{
-		client: client,
-	}
-	var movementList []models.Movement
-
-	for i := 0; i < 52; i++ {
-		createdMovement, err := movementRepo.CreateNewMovement(models.Movement{
-			Name:         "Test movement N" + strconv.Itoa(i),
-			OwnerId:      "0",
-			SourceID:     sourceID,
-			MovementDate: time.Now().AddDate(0, 0, -i).UTC().Truncate(time.Hour * 24),
-		})
-		if err != nil {
-			t.Fatalf("Cant connect to Firestore to create test movement: %s", err.Error())
-		}
-		movementList = append(movementList, createdMovement)
-	}
-	return movementList
-}
-
-func deleteTestMovementList(client *firestore.Client, movements []models.Movement) {
-	for _, movement := range movements {
-		deleteTestMovement(client, movement.UID)
-	}
-}
-
-func deleteTestMovement(client *firestore.Client, id string) {
-	args := map[string]interface{}{
-		"Collection": "movements",
-		"id":         id,
-	}
-	test_utils.ClearFireStoreTest(client, "Create", args)
 }
 
 func checkEqualMovement(t *testing.T, expected models.Movement, got models.Movement) {

--- a/repository/movement_repo_test.go
+++ b/repository/movement_repo_test.go
@@ -115,7 +115,7 @@ func Test_movementRepositoryImplementation_GetMovementByID(t *testing.T) {
 
 	createdOwner := firestore_utils.CreateTestUser(t, firestoreClient, "0")
 	createdSource := firestore_utils.CreateTestSource(t, firestoreClient, createdOwner.UID)
-	createdMovement := createTestMovement(t, firestoreClient, createdSource.UID)
+	createdMovement := firestore_utils.CreateTestMovement(t, firestoreClient, createdOwner.UID, createdSource.UID)
 
 	testFields := test_utils.Fields{
 		"firestoreClient": firestoreClient,
@@ -325,7 +325,7 @@ func Test_movementRepositoryImplementation_UpdateMovement(t *testing.T) {
 
 	createdOwner := firestore_utils.CreateTestUser(t, firestoreClient, "0")
 	createdSource := firestore_utils.CreateTestSource(t, firestoreClient, createdOwner.UID)
-	createdMovement := createTestMovement(t, firestoreClient, createdSource.UID)
+	createdMovement := firestore_utils.CreateTestMovement(t, firestoreClient, createdOwner.UID, createdSource.UID)
 	updatedMovement := models.Movement{
 		UID:          createdMovement.UID,
 		Name:         "Update Movement",
@@ -439,7 +439,7 @@ func Test_movementRepositoryImplementation_DeleteMovement(t *testing.T) {
 
 	createdOwner := firestore_utils.CreateTestUser(t, firestoreClient, "0")
 	createdSource := firestore_utils.CreateTestSource(t, firestoreClient, createdOwner.UID)
-	createdMovement := createTestMovement(t, firestoreClient, createdSource.UID)
+	createdMovement := firestore_utils.CreateTestMovement(t, firestoreClient, createdOwner.UID, createdSource.UID)
 
 	testFields := test_utils.Fields{
 		"firestoreClient": firestoreClient,
@@ -517,24 +517,6 @@ func Test_movementRepositoryImplementation_DeleteMovement(t *testing.T) {
 	}
 	firestore_utils.DeleteTestSource(t, firestoreClient, createdSource.UID)
 	firestore_utils.DeleteTestUser(t, firestoreClient, createdOwner.UID)
-}
-
-func createTestMovement(t *testing.T, client *firestore.Client, sourceID string) models.Movement {
-	testMovement := movementRepositoryImplementation{
-		client: client,
-	}
-
-	res, err := testMovement.CreateNewMovement(models.Movement{
-		Name:     "test Owner",
-		SourceID: sourceID,
-		OwnerId:  "0",
-	})
-
-	if err != nil {
-		t.Fatalf("Cant connect to Firestore to create test source: %s", err.Error())
-	}
-
-	return res
 }
 
 func createTestMovementList(t *testing.T, client *firestore.Client, sourceID string) []models.Movement {

--- a/repository/movement_repo_test.go
+++ b/repository/movement_repo_test.go
@@ -205,7 +205,7 @@ func Test_movementRepositoryImplementation_GetMovementsByUserAndDate(t *testing.
 
 	createdOwner := firestore_utils.CreateTestUser(t, firestoreClient, "0")
 	createdSource := firestore_utils.CreateTestSource(t, firestoreClient, createdOwner.UID)
-	createdMovements := createTestMovementList(t, firestoreClient, createdSource.UID)
+	createdMovements := firestore_utils.CreateTestMovementList(t, firestoreClient, createdOwner.UID, createdSource.UID)
 
 	testFields := test_utils.Fields{
 		"firestoreClient": firestoreClient,

--- a/repository/source_repo_test.go
+++ b/repository/source_repo_test.go
@@ -177,8 +177,10 @@ func TestSourceRepositoryImplementation_GetMovementsBySourceAndDate(t *testing.T
 		})
 	}
 	deleteTestMovementList(firestoreClient, createdMovements)
-	firestore_utils.DeleteTestSource(t, firestoreClient, createdSourceUID.UID)
-	firestore_utils.DeleteTestUser(t, firestoreClient, createdOwner.UID)
+	defer func() {
+		firestore_utils.DeleteTestSource(t, firestoreClient, createdSourceUID.UID)
+		firestore_utils.DeleteTestUser(t, firestoreClient, createdOwner.UID)
+	}()
 }
 
 func TestSourceRepositoryImplementation_CreateNewSource(t *testing.T) {
@@ -255,7 +257,7 @@ func TestSourceRepositoryImplementation_CreateNewSource(t *testing.T) {
 			}()
 		})
 	}
-	firestore_utils.DeleteTestUser(t, firestoreClient, createdOwner.UID)
+	defer firestore_utils.DeleteTestUser(t, firestoreClient, createdOwner.UID)
 }
 
 func TestSourceRepositoryImplementation_GetSourcesByUser(t *testing.T) {
@@ -346,8 +348,10 @@ func TestSourceRepositoryImplementation_GetSourcesByUser(t *testing.T) {
 			}
 		})
 	}
-	firestore_utils.DeleteTestSourceList(t, firestoreClient, createdSources)
-	firestore_utils.DeleteTestUser(t, firestoreClient, createdOwner.UID)
+	defer func() {
+		firestore_utils.DeleteTestSourceList(t, firestoreClient, createdSources)
+		firestore_utils.DeleteTestUser(t, firestoreClient, createdOwner.UID)
+	}()
 }
 
 func TestSourceRepositoryImplementation_GetSourceByID(t *testing.T) {
@@ -433,8 +437,10 @@ func TestSourceRepositoryImplementation_GetSourceByID(t *testing.T) {
 			}
 		})
 	}
-	firestore_utils.DeleteTestSource(t, firestoreClient, createdSourceUID.UID)
-	firestore_utils.DeleteTestUser(t, firestoreClient, createdOwner.UID)
+	defer func() {
+		firestore_utils.DeleteTestSource(t, firestoreClient, createdSourceUID.UID)
+		firestore_utils.DeleteTestUser(t, firestoreClient, createdOwner.UID)
+	}()
 }
 
 func TestSourceRepositoryImplementation_UpdateSource(t *testing.T) {
@@ -591,7 +597,7 @@ func TestSourceRepositoryImplementation_DeleteSource(t *testing.T) {
 			}
 		})
 	}
-	firestore_utils.DeleteTestUser(t, firestoreClient, createdOwner.UID)
+	defer firestore_utils.DeleteTestUser(t, firestoreClient, createdOwner.UID)
 }
 
 func checkEqualSource(t *testing.T, expected models.Source, got models.Source) {

--- a/repository/source_repo_test.go
+++ b/repository/source_repo_test.go
@@ -12,51 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func createTestOwner(t *testing.T, firestoreClient *firestore.Client) {
-	userDuplicated := &UserRepositoryImplementation{
-		client: firestoreClient,
-	}
-
-	err := userDuplicated.CreateNewUser(models.User{UID: "0", Alias: "TEST USER"})
-	if err != nil {
-		t.Fatalf("Cant connect to Firestore to create test user: %s", err.Error())
-	}
-}
-
-func createTestSource(t *testing.T, firestoreClient *firestore.Client) string {
-	userDuplicated := &SourceRepositoryImplementation{
-		client: firestoreClient,
-	}
-
-	res, err := userDuplicated.CreateNewSource(models.Source{
-		UID:       "0",
-		Name:      "Test Source",
-		OwnerId:   "0",
-		CreatedAt: time.Now(),
-		UpdatedAt: time.Now(),
-	})
-	if err != nil {
-		t.Fatalf("Cant connect to Firestore to create test source: %s", err.Error())
-	}
-	return res.UID
-}
-
-func deleteTestSource(firestoreClient *firestore.Client, id string) {
-	args := map[string]interface{}{
-		"Collection": "sources",
-		"id":         id,
-	}
-	test_utils.ClearFireStoreTest(firestoreClient, "Create", args)
-}
-
-func deleteTestUser(firestoreClient *firestore.Client) {
-	args := map[string]interface{}{
-		"Collection": "users",
-		"id":         "0",
-	}
-	test_utils.ClearFireStoreTest(firestoreClient, "Create", args)
-}
-
 func TestSourceRepositoryImplementation_GetMovementsBySourceAndDate(t *testing.T) {
 
 	firestoreClient := test_utils.InitTestingFireStore(t)

--- a/repository/source_repo_test.go
+++ b/repository/source_repo_test.go
@@ -213,8 +213,8 @@ func TestSourceRepositoryImplementation_GetMovementsBySourceAndDate(t *testing.T
 		})
 	}
 	deleteTestMovementList(firestoreClient, createdMovements)
-	deleteTestSource(firestoreClient, createdSourceUID.UID)
-	deleteTestUser(firestoreClient)
+	firestore_utils.DeleteTestSource(t, firestoreClient, createdSourceUID.UID)
+	firestore_utils.DeleteTestUser(t, firestoreClient, createdOwner.UID)
 }
 
 func TestSourceRepositoryImplementation_CreateNewSource(t *testing.T) {
@@ -261,7 +261,7 @@ func TestSourceRepositoryImplementation_CreateNewSource(t *testing.T) {
 		},
 	}
 
-	firestore_utils.CreateTestUser(t, firestoreClient, "0")
+	createdOwner := firestore_utils.CreateTestUser(t, firestoreClient, "0")
 
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
@@ -291,7 +291,7 @@ func TestSourceRepositoryImplementation_CreateNewSource(t *testing.T) {
 			}()
 		})
 	}
-	deleteTestUser(firestoreClient)
+	firestore_utils.DeleteTestUser(t, firestoreClient, createdOwner.UID)
 }
 
 func TestSourceRepositoryImplementation_GetSourcesByUser(t *testing.T) {
@@ -299,7 +299,7 @@ func TestSourceRepositoryImplementation_GetSourcesByUser(t *testing.T) {
 	firestoreClient := test_utils.InitTestingFireStore(t)
 	firestoreClientFail := test_utils.InitTestingFireStoreFail(t)
 
-	firestore_utils.CreateTestUser(t, firestoreClient, "0")
+	createdOwner := firestore_utils.CreateTestUser(t, firestoreClient, "0")
 	createdSources := createTestSourceList(t, firestoreClient)
 
 	testFields := test_utils.Fields{
@@ -383,7 +383,7 @@ func TestSourceRepositoryImplementation_GetSourcesByUser(t *testing.T) {
 		})
 	}
 	deleteTestSourceList(firestoreClient, createdSources)
-	deleteTestUser(firestoreClient)
+	firestore_utils.DeleteTestUser(t, firestoreClient, createdOwner.UID)
 }
 
 func TestSourceRepositoryImplementation_GetSourceByID(t *testing.T) {
@@ -469,8 +469,8 @@ func TestSourceRepositoryImplementation_GetSourceByID(t *testing.T) {
 			}
 		})
 	}
-	deleteTestSource(firestoreClient, createdSourceUID.UID)
-	deleteTestUser(firestoreClient)
+	firestore_utils.DeleteTestSource(t, firestoreClient, createdSourceUID.UID)
+	firestore_utils.DeleteTestUser(t, firestoreClient, createdOwner.UID)
 }
 
 func TestSourceRepositoryImplementation_UpdateSource(t *testing.T) {
@@ -555,8 +555,8 @@ func TestSourceRepositoryImplementation_UpdateSource(t *testing.T) {
 		})
 	}
 	defer func() {
-		deleteTestSource(firestoreClient, createdSourceUID.UID)
-		deleteTestUser(firestoreClient)
+		firestore_utils.DeleteTestSource(t, firestoreClient, createdSourceUID.UID)
+		firestore_utils.DeleteTestUser(t, firestoreClient, createdOwner.UID)
 	}()
 }
 
@@ -627,7 +627,7 @@ func TestSourceRepositoryImplementation_DeleteSource(t *testing.T) {
 			}
 		})
 	}
-	deleteTestUser(firestoreClient)
+	firestore_utils.DeleteTestUser(t, firestoreClient, createdOwner.UID)
 }
 
 func checkEqualSource(t *testing.T, expected models.Source, got models.Source) {

--- a/repository/source_repo_test.go
+++ b/repository/source_repo_test.go
@@ -1,7 +1,6 @@
 package repository
 
 import (
-	"strconv"
 	"testing"
 	"time"
 
@@ -40,41 +39,6 @@ func createTestSource(t *testing.T, firestoreClient *firestore.Client) string {
 		t.Fatalf("Cant connect to Firestore to create test source: %s", err.Error())
 	}
 	return res.UID
-}
-
-func createTestSourceList(t *testing.T, firestoreClient *firestore.Client) []string {
-	userDuplicated := &SourceRepositoryImplementation{
-		client: firestoreClient,
-	}
-
-	createdIDs := []string{}
-
-	for i := 0; i < 51; i++ {
-		createdSource, err := userDuplicated.CreateNewSource(models.Source{
-			UID:       "0",
-			Name:      "Test Source N" + strconv.Itoa(i),
-			OwnerId:   "0",
-			CreatedAt: time.Now(),
-			UpdatedAt: time.Now(),
-		})
-		if err != nil {
-			t.Fatalf("Cant connect to Firestore to create test source: %s", err.Error())
-		}
-
-		createdIDs = append(createdIDs, createdSource.UID)
-
-	}
-	return createdIDs
-}
-
-func deleteTestSourceList(firestoreClient *firestore.Client, idList []string) {
-	for _, id := range idList {
-		args := map[string]interface{}{
-			"Collection": "sources",
-			"id":         id,
-		}
-		test_utils.ClearFireStoreTest(firestoreClient, "Create", args)
-	}
 }
 
 func deleteTestSource(firestoreClient *firestore.Client, id string) {
@@ -300,7 +264,7 @@ func TestSourceRepositoryImplementation_GetSourcesByUser(t *testing.T) {
 	firestoreClientFail := test_utils.InitTestingFireStoreFail(t)
 
 	createdOwner := firestore_utils.CreateTestUser(t, firestoreClient, "0")
-	createdSources := createTestSourceList(t, firestoreClient)
+	createdSources := firestore_utils.CreateTestSourceList(t, firestoreClient, createdOwner.UID)
 
 	testFields := test_utils.Fields{
 		"firestoreClient": firestoreClient,
@@ -382,7 +346,7 @@ func TestSourceRepositoryImplementation_GetSourcesByUser(t *testing.T) {
 			}
 		})
 	}
-	deleteTestSourceList(firestoreClient, createdSources)
+	firestore_utils.DeleteTestSourceList(t, firestoreClient, createdSources)
 	firestore_utils.DeleteTestUser(t, firestoreClient, createdOwner.UID)
 }
 

--- a/repository/source_repo_test.go
+++ b/repository/source_repo_test.go
@@ -19,7 +19,7 @@ func TestSourceRepositoryImplementation_GetMovementsBySourceAndDate(t *testing.T
 
 	createdOwner := firestore_utils.CreateTestUser(t, firestoreClient, "0")
 	createdSourceUID := firestore_utils.CreateTestSource(t, firestoreClient, createdOwner.UID)
-	createdMovements := createTestMovementList(t, firestoreClient, createdSourceUID.UID)
+	createdMovements := firestore_utils.CreateTestMovementList(t, firestoreClient, createdOwner.UID, createdSourceUID.UID)
 
 	testFields := test_utils.Fields{
 		"firestoreClient": firestoreClient,
@@ -131,7 +131,7 @@ func TestSourceRepositoryImplementation_GetMovementsBySourceAndDate(t *testing.T
 			}
 		})
 	}
-	deleteTestMovementList(firestoreClient, createdMovements)
+	firestore_utils.DeleteTestMovementList(t, firestoreClient, createdMovements)
 	defer func() {
 		firestore_utils.DeleteTestSource(t, firestoreClient, createdSourceUID.UID)
 		firestore_utils.DeleteTestUser(t, firestoreClient, createdOwner.UID)

--- a/repository/user_repo_test.go
+++ b/repository/user_repo_test.go
@@ -27,7 +27,7 @@ func TestUserRepositoryImplementation_CreateNewUser(t *testing.T) {
 				"firestoreClient": firestoreClient,
 			},
 			Args: test_utils.Args{
-				"user": models.User{UID: "0", Alias: "TestUser"},
+				"user": firestore_utils.SetTestUserID("0"),
 			},
 			WantErr:     false,
 			ExpectedErr: nil,
@@ -77,13 +77,8 @@ func TestUserRepositoryImplementation_CreateNewUser(t *testing.T) {
 					assert.ErrorAs(t, err, &tt.ExpectedErr, "Expected: %s\nGot: %s", tt.ExpectedErr.Error(), err.Error())
 				}
 			}
-			args := map[string]interface{}{
-				"Collection": "users",
-				"id":         userTest.UID,
-			}
-			test_utils.ClearFireStoreTest(firestoreClient, "Create", args)
+			defer firestore_utils.DeleteTestUser(t, firestoreClient, userTest.UID)
 		})
-
 	}
 }
 
@@ -154,9 +149,5 @@ func TestUserRepositoryImplementation_GetUserByID(t *testing.T) {
 			}
 		})
 	}
-	args := test_utils.Args{
-		"Collection": "users",
-		"id":         searchUser.UID,
-	}
-	defer test_utils.ClearFireStoreTest(firestoreClient, "Create", args)
+	defer firestore_utils.DeleteTestUser(t, firestoreClient, searchUser.UID)
 }

--- a/utils/test/firestore/movement.go
+++ b/utils/test/firestore/movement.go
@@ -58,34 +58,36 @@ func SetTestMovementData(movement models.Movement, uid string, ownerID string) m
 
 func CreateTestMovement(t *testing.T, client *firestore.Client, ownerID string, sourceID string) models.Movement {
 	movementDocRef := client.Collection("movements").NewDoc()
-	tUser := TestMovement
-	tUser.UID = movementDocRef.ID
-	tUser.OwnerId = ownerID
-	tUser.SourceID = sourceID
-	_, err := movementDocRef.Set(context.Background(), tUser)
+	tMovement := TestMovement
+	tMovement.UID = movementDocRef.ID
+	tMovement.OwnerId = ownerID
+	tMovement.SourceID = sourceID
+	_, err := movementDocRef.Set(context.Background(), tMovement)
 	if err != nil {
 		t.Fatalf("Can't create test movement: %s", err)
 	}
-	return tUser
+	return tMovement
 }
 
-func createTestMovementListItem(t *testing.T, client *firestore.Client, ownerID string, n int) models.Movement {
+func createTestMovementListItem(t *testing.T, client *firestore.Client, ownerID string, sourceID string, n int) models.Movement {
 	movementDocRef := client.Collection("movements").NewDoc()
-	tUser := TestMovement
-	tUser.UID = movementDocRef.ID
-	tUser.OwnerId = ownerID
-	tUser.Name += "_N" + fmt.Sprint(n)
-	_, err := movementDocRef.Set(context.Background(), tUser)
+	tMovement := TestMovement
+	tMovement.UID = movementDocRef.ID
+	tMovement.OwnerId = ownerID
+	tMovement.Name += "_N" + fmt.Sprint(n)
+	tMovement.SourceID = sourceID
+
+	_, err := movementDocRef.Set(context.Background(), tMovement)
 	if err != nil {
 		t.Fatalf("Can't create test movement: %s", err)
 	}
-	return tUser
+	return tMovement
 }
 
-func CreateTestMovementList(t *testing.T, client *firestore.Client, ownerID string) []models.Movement {
+func CreateTestMovementList(t *testing.T, client *firestore.Client, ownerID string, sourceID string) []models.Movement {
 	createdList := []models.Movement{}
 	for i := 0; i < 51; i++ {
-		createdList = append(createdList, createTestMovementListItem(t, client, ownerID, i))
+		createdList = append(createdList, createTestMovementListItem(t, client, ownerID, sourceID, i))
 	}
 
 	return createdList

--- a/utils/test/firestore/movement.go
+++ b/utils/test/firestore/movement.go
@@ -1,8 +1,11 @@
 package firestore
 
 import (
+	"context"
+	"testing"
 	"time"
 
+	"cloud.google.com/go/firestore"
 	"github.com/AndresCRamos/midas-app-api/models"
 )
 
@@ -45,3 +48,21 @@ var (
 		UpdatedAt:   time.Now(),
 	}
 )
+
+func SetTestMovementData(movement models.Movement, uid string, ownerID string) models.Movement {
+	movement.UID = uid
+	movement.OwnerId = ownerID
+	return movement
+}
+
+func CreateTestMovement(t *testing.T, client *firestore.Client, ownerID string) models.Movement {
+	movementDocRef := client.Collection("movements").NewDoc()
+	tUser := TestMovement
+	tUser.UID = movementDocRef.ID
+	tUser.OwnerId = ownerID
+	_, err := movementDocRef.Set(context.Background(), tUser)
+	if err != nil {
+		t.Fatalf("Can't create test movement: %s", err)
+	}
+	return tUser
+}

--- a/utils/test/firestore/movement.go
+++ b/utils/test/firestore/movement.go
@@ -56,11 +56,12 @@ func SetTestMovementData(movement models.Movement, uid string, ownerID string) m
 	return movement
 }
 
-func CreateTestMovement(t *testing.T, client *firestore.Client, ownerID string) models.Movement {
+func CreateTestMovement(t *testing.T, client *firestore.Client, ownerID string, sourceID string) models.Movement {
 	movementDocRef := client.Collection("movements").NewDoc()
 	tUser := TestMovement
 	tUser.UID = movementDocRef.ID
 	tUser.OwnerId = ownerID
+	tUser.SourceID = sourceID
 	_, err := movementDocRef.Set(context.Background(), tUser)
 	if err != nil {
 		t.Fatalf("Can't create test movement: %s", err)

--- a/utils/test/firestore/movement.go
+++ b/utils/test/firestore/movement.go
@@ -50,18 +50,17 @@ var (
 	}
 )
 
-func SetTestMovementData(movement models.Movement, uid string, ownerID string) models.Movement {
+func SetTestMovementData(movement models.Movement, uid string, ownerID string, sourceID string, movementDate time.Time) models.Movement {
 	movement.UID = uid
 	movement.OwnerId = ownerID
+	movement.SourceID = sourceID
+	movement.MovementDate = movementDate.UTC().Truncate(24 * time.Hour)
 	return movement
 }
 
 func CreateTestMovement(t *testing.T, client *firestore.Client, ownerID string, sourceID string) models.Movement {
 	movementDocRef := client.Collection("movements").NewDoc()
-	tMovement := TestMovement
-	tMovement.UID = movementDocRef.ID
-	tMovement.OwnerId = ownerID
-	tMovement.SourceID = sourceID
+	tMovement := SetTestMovementData(TestMovement, movementDocRef.ID, ownerID, sourceID, time.Now())
 	_, err := movementDocRef.Set(context.Background(), tMovement)
 	if err != nil {
 		t.Fatalf("Can't create test movement: %s", err)
@@ -71,11 +70,8 @@ func CreateTestMovement(t *testing.T, client *firestore.Client, ownerID string, 
 
 func createTestMovementListItem(t *testing.T, client *firestore.Client, ownerID string, sourceID string, n int) models.Movement {
 	movementDocRef := client.Collection("movements").NewDoc()
-	tMovement := TestMovement
-	tMovement.UID = movementDocRef.ID
-	tMovement.OwnerId = ownerID
+	tMovement := SetTestMovementData(TestMovement, movementDocRef.ID, ownerID, sourceID, time.Now())
 	tMovement.Name += "_N" + fmt.Sprint(n)
-	tMovement.SourceID = sourceID
 
 	_, err := movementDocRef.Set(context.Background(), tMovement)
 	if err != nil {

--- a/utils/test/firestore/movement.go
+++ b/utils/test/firestore/movement.go
@@ -1,0 +1,47 @@
+package firestore
+
+import (
+	"time"
+
+	"github.com/AndresCRamos/midas-app-api/models"
+)
+
+var (
+	TestMovementCreate = models.MovementCreate{
+		Name:        "TEST_SOURCE",
+		Description: "TEST DESCRIPTION",
+	}
+
+	TestMovementRetrieve = models.MovementRetrieve{
+		Name:        "TEST_SOURCE",
+		Description: "TEST DESCRIPTION",
+		CreatedAt:   time.Now(),
+		UpdatedAt:   time.Now(),
+	}
+
+	TestMovementUpdated = models.Movement{
+		Name:        "TEST_SOURCE",
+		Description: "TEST DESCRIPTION UPDATED",
+		CreatedAt:   time.Now(),
+		UpdatedAt:   time.Now(),
+	}
+
+	TestMovementRetrieveUpdated = models.MovementRetrieve{
+		Name:        "TEST_SOURCE",
+		Description: "TEST DESCRIPTION UPDATED",
+		CreatedAt:   time.Now(),
+		UpdatedAt:   time.Now(),
+	}
+
+	TestMovementUpdate = models.MovementUpdate{
+		Name:        "TEST_SOURCE",
+		Description: "TEST DESCRIPTION UPDATED",
+	}
+
+	TestMovement = models.Movement{
+		Name:        "TEST_SOURCE",
+		Description: "TEST DESCRIPTION",
+		CreatedAt:   time.Now(),
+		UpdatedAt:   time.Now(),
+	}
+)

--- a/utils/test/firestore/movement.go
+++ b/utils/test/firestore/movement.go
@@ -70,7 +70,7 @@ func CreateTestMovement(t *testing.T, client *firestore.Client, ownerID string, 
 
 func createTestMovementListItem(t *testing.T, client *firestore.Client, ownerID string, sourceID string, n int) models.Movement {
 	movementDocRef := client.Collection("movements").NewDoc()
-	tMovement := SetTestMovementData(TestMovement, movementDocRef.ID, ownerID, sourceID, time.Now())
+	tMovement := SetTestMovementData(TestMovement, movementDocRef.ID, ownerID, sourceID, time.Now().AddDate(0, 0, -n))
 	tMovement.Name += "_N" + fmt.Sprint(n)
 
 	_, err := movementDocRef.Set(context.Background(), tMovement)

--- a/utils/test/firestore/movement.go
+++ b/utils/test/firestore/movement.go
@@ -2,6 +2,7 @@ package firestore
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -65,4 +66,26 @@ func CreateTestMovement(t *testing.T, client *firestore.Client, ownerID string) 
 		t.Fatalf("Can't create test movement: %s", err)
 	}
 	return tUser
+}
+
+func createTestMovementListItem(t *testing.T, client *firestore.Client, ownerID string, n int) models.Movement {
+	movementDocRef := client.Collection("movements").NewDoc()
+	tUser := TestMovement
+	tUser.UID = movementDocRef.ID
+	tUser.OwnerId = ownerID
+	tUser.Name += "_N" + fmt.Sprint(n)
+	_, err := movementDocRef.Set(context.Background(), tUser)
+	if err != nil {
+		t.Fatalf("Can't create test movement: %s", err)
+	}
+	return tUser
+}
+
+func CreateTestMovementList(t *testing.T, client *firestore.Client, ownerID string) []models.Movement {
+	createdList := []models.Movement{}
+	for i := 0; i < 51; i++ {
+		createdList = append(createdList, createTestMovementListItem(t, client, ownerID, i))
+	}
+
+	return createdList
 }

--- a/utils/test/firestore/movement.go
+++ b/utils/test/firestore/movement.go
@@ -82,7 +82,7 @@ func createTestMovementListItem(t *testing.T, client *firestore.Client, ownerID 
 
 func CreateTestMovementList(t *testing.T, client *firestore.Client, ownerID string, sourceID string) []models.Movement {
 	createdList := []models.Movement{}
-	for i := 0; i < 51; i++ {
+	for i := 0; i < 52; i++ {
 		createdList = append(createdList, createTestMovementListItem(t, client, ownerID, sourceID, i))
 	}
 

--- a/utils/test/firestore/movement.go
+++ b/utils/test/firestore/movement.go
@@ -89,3 +89,17 @@ func CreateTestMovementList(t *testing.T, client *firestore.Client, ownerID stri
 
 	return createdList
 }
+
+func DeleteTestMovementList(t *testing.T, client *firestore.Client, deleteMovements []models.Movement) {
+	for _, movement := range deleteMovements {
+		DeleteTestMovement(t, client, movement.UID)
+	}
+}
+
+func DeleteTestMovement(t *testing.T, client *firestore.Client, uid string) {
+	_, err := client.Collection("movements").Doc(uid).Delete(context.Background())
+
+	if err != nil {
+		t.Logf("Cant delete test user: %s", err.Error())
+	}
+}

--- a/utils/test/firestore/sources.go
+++ b/utils/test/firestore/sources.go
@@ -2,6 +2,7 @@ package firestore
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -65,6 +66,34 @@ func CreateTestSource(t *testing.T, client *firestore.Client, ownerID string) mo
 		t.Fatalf("Can't create test source: %s", err)
 	}
 	return tUser
+}
+
+func createTestSourceListItem(t *testing.T, client *firestore.Client, ownerID string, n int) models.Source {
+	sourceDocRef := client.Collection("sources").NewDoc()
+	tUser := TestSource
+	tUser.UID = sourceDocRef.ID
+	tUser.OwnerId = ownerID
+	tUser.Name += "_N" + fmt.Sprint(n)
+	_, err := sourceDocRef.Set(context.Background(), tUser)
+	if err != nil {
+		t.Fatalf("Can't create test source: %s", err)
+	}
+	return tUser
+}
+
+func CreateTestSourceList(t *testing.T, client *firestore.Client, ownerID string) []models.Source {
+	createdList := []models.Source{}
+	for i := 0; i < 51; i++ {
+		createdList = append(createdList, createTestSourceListItem(t, client, ownerID, i))
+	}
+
+	return createdList
+}
+
+func DeleteTestSourceList(t *testing.T, client *firestore.Client, deleteSources []models.Source) {
+	for _, source := range deleteSources {
+		DeleteTestSource(t, client, source.UID)
+	}
 }
 
 func DeleteTestSource(t *testing.T, client *firestore.Client, uid string) {

--- a/utils/test/firestore/sources.go
+++ b/utils/test/firestore/sources.go
@@ -1,8 +1,11 @@
 package firestore
 
 import (
+	"context"
+	"testing"
 	"time"
 
+	"cloud.google.com/go/firestore"
 	"github.com/AndresCRamos/midas-app-api/models"
 )
 
@@ -19,9 +22,16 @@ var (
 		UpdatedAt:   time.Now(),
 	}
 
+	TestSourceRetrieveUpdated = models.SourceRetrieve{
+		Name:        "TEST_SOURCE",
+		Description: "TEST DESCRIPTION UPDATED",
+		CreatedAt:   time.Now(),
+		UpdatedAt:   time.Now(),
+	}
+
 	TestSourceUpdate = models.SourceUpdate{
 		Name:        "TEST_SOURCE",
-		Description: "TEST DESCRIPTION",
+		Description: "TEST DESCRIPTION UPDATED",
 	}
 
 	TestSource = models.Source{
@@ -31,3 +41,15 @@ var (
 		UpdatedAt:   time.Now(),
 	}
 )
+
+func CreateTestSource(t *testing.T, client *firestore.Client, ownerID string) models.Source {
+	sourceDocRef := client.Collection("sources").NewDoc()
+	tUser := TestSource
+	tUser.UID = sourceDocRef.ID
+	tUser.OwnerId = ownerID
+	_, err := sourceDocRef.Set(context.Background(), tUser)
+	if err != nil {
+		t.Fatalf("Can't create test source: %s", err)
+	}
+	return tUser
+}

--- a/utils/test/firestore/sources.go
+++ b/utils/test/firestore/sources.go
@@ -22,6 +22,13 @@ var (
 		UpdatedAt:   time.Now(),
 	}
 
+	TestSourceUpdated = models.Source{
+		Name:        "TEST_SOURCE",
+		Description: "TEST DESCRIPTION UPDATED",
+		CreatedAt:   time.Now(),
+		UpdatedAt:   time.Now(),
+	}
+
 	TestSourceRetrieveUpdated = models.SourceRetrieve{
 		Name:        "TEST_SOURCE",
 		Description: "TEST DESCRIPTION UPDATED",
@@ -41,6 +48,12 @@ var (
 		UpdatedAt:   time.Now(),
 	}
 )
+
+func SetTestSourceData(source models.Source, uid string, ownerID string) models.Source {
+	source.UID = uid
+	source.OwnerId = ownerID
+	return source
+}
 
 func CreateTestSource(t *testing.T, client *firestore.Client, ownerID string) models.Source {
 	sourceDocRef := client.Collection("sources").NewDoc()

--- a/utils/test/firestore/sources.go
+++ b/utils/test/firestore/sources.go
@@ -66,3 +66,11 @@ func CreateTestSource(t *testing.T, client *firestore.Client, ownerID string) mo
 	}
 	return tUser
 }
+
+func DeleteTestSource(t *testing.T, client *firestore.Client, uid string) {
+	_, err := client.Collection("sources").Doc(uid).Delete(context.Background())
+
+	if err != nil {
+		t.Logf("Cant delete test user: %s", err.Error())
+	}
+}

--- a/utils/test/firestore/sources.go
+++ b/utils/test/firestore/sources.go
@@ -1,0 +1,33 @@
+package firestore
+
+import (
+	"time"
+
+	"github.com/AndresCRamos/midas-app-api/models"
+)
+
+var (
+	TestSourceCreate = models.SourceCreate{
+		Name:        "TEST_SOURCE",
+		Description: "TEST DESCRIPTION",
+	}
+
+	TestSourceRetrieve = models.SourceRetrieve{
+		Name:        "TEST_SOURCE",
+		Description: "TEST DESCRIPTION",
+		CreatedAt:   time.Now(),
+		UpdatedAt:   time.Now(),
+	}
+
+	TestSourceUpdate = models.SourceUpdate{
+		Name:        "TEST_SOURCE",
+		Description: "TEST DESCRIPTION",
+	}
+
+	TestSource = models.Source{
+		Name:        "TEST_SOURCE",
+		Description: "TEST DESCRIPTION",
+		CreatedAt:   time.Now(),
+		UpdatedAt:   time.Now(),
+	}
+)

--- a/utils/test/firestore/user.go
+++ b/utils/test/firestore/user.go
@@ -33,3 +33,12 @@ func CreateTestUser(t *testing.T, client *firestore.Client, uid string) models.U
 
 	return tUser
 }
+
+func DeleteTestUser(t *testing.T, client *firestore.Client, uid string) {
+	_, err := client.Collection("users").Doc(uid).Delete(context.Background())
+
+	if err != nil {
+		t.Fatalf("Cant delete test user: %s", err.Error())
+	}
+
+}

--- a/utils/test/firestore/user.go
+++ b/utils/test/firestore/user.go
@@ -38,7 +38,7 @@ func DeleteTestUser(t *testing.T, client *firestore.Client, uid string) {
 	_, err := client.Collection("users").Doc(uid).Delete(context.Background())
 
 	if err != nil {
-		t.Fatalf("Cant delete test user: %s", err.Error())
+		t.Logf("Cant delete test user: %s", err.Error())
 	}
 
 }

--- a/utils/test/firestore/user.go
+++ b/utils/test/firestore/user.go
@@ -31,5 +31,5 @@ func CreateTestUser(t *testing.T, client *firestore.Client, uid string) models.U
 		t.Fatalf("Can't create test user: %s", err)
 	}
 
-	return TestUser
+	return tUser
 }

--- a/utils/test/firestore/user.go
+++ b/utils/test/firestore/user.go
@@ -1,0 +1,26 @@
+package firestore
+
+import (
+	"context"
+	"testing"
+
+	"cloud.google.com/go/firestore"
+	"github.com/AndresCRamos/midas-app-api/models"
+)
+
+func CreateTestUser(t *testing.T, client *firestore.Client, uid string) models.User {
+	testUser := models.User{
+		UID:      uid,
+		Alias:    "TEST_USER",
+		Name:     "John",
+		LastName: "Doe",
+	}
+
+	_, err := client.Collection("user").Doc(uid).Set(context.Background(), testUser)
+
+	if err != nil {
+		t.Fatalf("Can't create test user: %s", err)
+	}
+
+	return testUser
+}

--- a/utils/test/firestore/user.go
+++ b/utils/test/firestore/user.go
@@ -8,19 +8,28 @@ import (
 	"github.com/AndresCRamos/midas-app-api/models"
 )
 
-func CreateTestUser(t *testing.T, client *firestore.Client, uid string) models.User {
-	testUser := models.User{
-		UID:      uid,
+var (
+	TestUser = models.User{
 		Alias:    "TEST_USER",
 		Name:     "John",
 		LastName: "Doe",
 	}
+)
 
-	_, err := client.Collection("user").Doc(uid).Set(context.Background(), testUser)
+func SetTestUserID(uid string) models.User {
+	tUser := TestUser
+	tUser.UID = uid
+	return tUser
+}
+
+func CreateTestUser(t *testing.T, client *firestore.Client, uid string) models.User {
+	tUser := SetTestUserID(uid)
+
+	_, err := client.Collection("users").Doc(uid).Set(context.Background(), tUser)
 
 	if err != nil {
 		t.Fatalf("Can't create test user: %s", err)
 	}
 
-	return testUser
+	return TestUser
 }


### PR DESCRIPTION
# Firestore test utils

Create helper functions to create and delete test data for repositories:

Implemented functions are:

1. Users:
    - CreateTestUser(t *testing.T, client \*firestore.Client, uid string) models.User
        Creates a test user with the specified ID and returns it, fails the test if an error happens
    - DeleteTestUser(t *testing.T, client \*firestore.Client, uid string)
        Deletes a user with the specified ID, logs to the test if an error occurs
2. Sources:
    - CreateTestSource(t *testing.T, client \*firestore.Client, ownerID string) models.Source
        Create a test source with the specified owner and returns it, fails the test if an error happens
    - CreateTestSourceList(t *testing.T, client \*firestore.Client, ownerID string) []models.Source
        Creates a list of test sources, with names according to their creation order and returns them, fails if encounters an error
    - DeleteTestSource(t *testing.T, client \*firestore.Client, uid string)
        Deletes a source, log in test if an error happens
    - DeleteTestSourceList(t *testing.T, client \*firestore.Client, deleteSources []models.Source)
        Deletes a list of sources, logs any encountered error
3. Movements:
    - CreateTestMovement(t *testing.T, client \*firestore.Client, ownerID string, sourceID string) models.Movement
        Create a test movement with the specified owner and source and returns it, fails the test if an error happens
    - CreateTestMovementList(t *testing.T, client \*firestore.Client, ownerID string, sourceID string) []models.Movement
        Creates a list of test movements, with names according to their creation order and returns them, fails if encounters an error
    - DeleteTestMovement(t *testing.T, client \*firestore.Client, uid string)
        Deletes a movement, log in test if an error happens
    - DeleteTestMovementList(t *testing.T, client \*firestore.Client, deleteMovements []models.Movement)
        Deletes a list of movements, logs any encountered error
