### PR TITLE
Feature/compare models

### DIFF
--- a/utils/test/compare/movement.go
+++ b/utils/test/compare/movement.go
@@ -1,6 +1,8 @@
 package compare
 
 import (
+	"encoding/json"
+	"testing"
 	"time"
 
 	"github.com/AndresCRamos/midas-app-api/models"
@@ -41,4 +43,15 @@ func CompareMovements(expected models.Movement, got models.Movement, checkID boo
 
 	delta = expected.UpdatedAt.Sub(got.UpdatedAt)
 	return delta <= maxDelta
+}
+
+func ContainsMovement(t *testing.T, expectedList []models.Movement, got models.Movement, delta time.Duration) {
+	for _, elem := range expectedList {
+		if CompareMovements(elem, got, true, delta) {
+			return
+		}
+	}
+	bList, _ := json.MarshalIndent(expectedList, "", " ")
+	dList, _ := json.MarshalIndent(got, "", " ")
+	t.Fatalf("List\n%v\ndoes not contain\n%v", string(bList), string(dList))
 }

--- a/utils/test/compare/movement.go
+++ b/utils/test/compare/movement.go
@@ -1,0 +1,44 @@
+package compare
+
+import (
+	"time"
+
+	"github.com/AndresCRamos/midas-app-api/models"
+)
+
+func CompareMovements(expected models.Movement, got models.Movement, checkID bool, maxDelta time.Duration) bool {
+	if checkID {
+		if expected.UID != got.UID {
+			return false
+		}
+	}
+	if expected.OwnerId != got.OwnerId {
+		return false
+	}
+	if expected.SourceID != got.SourceID {
+		return false
+	}
+	if expected.Name != got.Name {
+		return false
+	}
+	if expected.Description != got.Description {
+		return false
+	}
+	if expected.Amount != got.Amount {
+		return false
+	}
+	if !expected.MovementDate.Equal(got.MovementDate) {
+		return false
+	}
+	if !CompareSlices(expected.Tags, got.Tags) {
+		return false
+	}
+
+	delta := expected.CreatedAt.Sub(got.CreatedAt)
+	if delta > maxDelta {
+		return false
+	}
+
+	delta = expected.UpdatedAt.Sub(got.UpdatedAt)
+	return delta <= maxDelta
+}

--- a/utils/test/compare/slice.go
+++ b/utils/test/compare/slice.go
@@ -1,0 +1,13 @@
+package compare
+
+func CompareSlices[T comparable](slice1, slice2 []T) bool {
+	if len(slice1) != len(slice2) {
+		return false
+	}
+	for i := range slice1 {
+		if slice1[i] != slice2[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/utils/test/compare/source.go
+++ b/utils/test/compare/source.go
@@ -1,6 +1,8 @@
 package compare
 
 import (
+	"encoding/json"
+	"testing"
 	"time"
 
 	"github.com/AndresCRamos/midas-app-api/models"
@@ -33,4 +35,15 @@ func CompareSources(expected models.Source, got models.Source, checkID bool, max
 	}
 
 	return expected.UpdatedAt.Sub(got.UpdatedAt).Abs() <= maxDelta.Abs()
+}
+
+func ContainsSource(t *testing.T, expectedList []models.Source, got models.Source, maxDelta time.Duration) {
+	for _, elem := range expectedList {
+		if CompareSources(elem, got, true, maxDelta) {
+			return
+		}
+	}
+	bList, _ := json.MarshalIndent(expectedList, "", " ")
+	dList, _ := json.MarshalIndent(got, "", " ")
+	t.Fatalf("List\n%v\ndoes not contain\n%v", string(bList), string(dList))
 }

--- a/utils/test/compare/source.go
+++ b/utils/test/compare/source.go
@@ -1,0 +1,36 @@
+package compare
+
+import (
+	"time"
+
+	"github.com/AndresCRamos/midas-app-api/models"
+)
+
+func CompareSources(expected models.Source, got models.Source, checkID bool, maxDelta time.Duration) bool {
+	if checkID {
+		if expected.UID != got.UID {
+			return false
+		}
+	}
+	if expected.UID != got.UID {
+		return false
+	}
+	if expected.OwnerId != got.OwnerId {
+		return false
+	}
+	if expected.Description != got.Description {
+		return false
+	}
+	if expected.Name != got.Name {
+		return false
+	}
+	if expected.Description != got.Description {
+		return false
+	}
+
+	if expected.CreatedAt.Sub(got.CreatedAt).Abs() > maxDelta.Abs() {
+		return false
+	}
+
+	return expected.UpdatedAt.Sub(got.UpdatedAt).Abs() <= maxDelta.Abs()
+}


### PR DESCRIPTION
# Compare models

Functions to compare structs, used for testing
- CompareSource: Receives an expected source, and compares it with another one, comparing if dates are between a declared delta, and comparing IDs if needed
- ContainsSource: Check if a slice of Sources, contains a given source, using CompareSource as checker
- CompareMovement: Receives an expected movement, and compares it with another one, comparing if dates are between a declared delta, and comparing IDs if needed
- ContainsSource: Check if a slice of movements, contains a given movement, using CompareMovement as checker
- CompareSlices: Generic function that checks if 2 slices have the same lenght, and the same items in the same order